### PR TITLE
clean up

### DIFF
--- a/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/utils/SecondaryVectorOperationsHelper.java
+++ b/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/utils/SecondaryVectorOperationsHelper.java
@@ -317,7 +317,6 @@ public class SecondaryVectorOperationsHelper extends SecondaryTreeIndexOperation
         outputRecFields[1] = serdeProvider.getSerializerDeserializer(AINT32);
         outputTypeTraits[1] = typeTraitProvider.getTypeTrait(AINT32);
 
-
         // Copy all original fields from secondaryRecDesc
         for (int i = 0; i < secondaryRecDesc.getFieldCount(); i++) {
             outputRecFields[2 + i] = secondaryRecDesc.getFields()[i];

--- a/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/operators/HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor.java
+++ b/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/operators/HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor.java
@@ -430,7 +430,7 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
             levelQueue.offer(maxLevel); // Start from root
             int treeLevel = 0;
             int globalCentroidId = 0;
-            
+
             while (!levelQueue.isEmpty()) {
                 int currentLevel = levelQueue.poll();
                 List<CentroidInfo> levelInfo = levelCentroids.get(currentLevel);
@@ -939,33 +939,31 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                         GeneratedRunFileReader in, FrameTupleAccessor fta, FrameTupleReference tuple,
                         IScalarEvaluator eval, IPointable inputVal, ListAccessor listAccessorConstant,
                         KMeansUtils kMeansUtils, int k, Random rand, int maxIterations, int totalTupleCount,
-                        int partition)
-                        throws HyracksDataException, IOException {
+                        int partition) throws HyracksDataException, IOException {
                     //   k-means|| configuration
                     int numRounds = 5; // Number of sampling rounds (default 5-10)
                     double oversamplingFactor = 2.0 * k; // Oversampling factor l ≈ 2k
-                    
-                    return performKMeansParallel(ctx, in, fta, tuple, eval, inputVal, listAccessorConstant,
-                            kMeansUtils, k, rand, maxIterations, totalTupleCount, partition, numRounds, oversamplingFactor);
+
+                    return performKMeansParallel(ctx, in, fta, tuple, eval, inputVal, listAccessorConstant, kMeansUtils,
+                            k, rand, maxIterations, totalTupleCount, partition, numRounds, oversamplingFactor);
                 }
-                
+
                 /**
                  * Implements   k-means|| algorithm with configurable parameters.
                  */
-                private ClusteringResult performKMeansParallel(IHyracksTaskContext ctx,
-                        GeneratedRunFileReader in, FrameTupleAccessor fta, FrameTupleReference tuple,
-                        IScalarEvaluator eval, IPointable inputVal, ListAccessor listAccessorConstant,
-                        KMeansUtils kMeansUtils, int k, Random rand, int maxIterations, int totalTupleCount,
-                        int partition, int numRounds, double oversamplingFactor)
+                private ClusteringResult performKMeansParallel(IHyracksTaskContext ctx, GeneratedRunFileReader in,
+                        FrameTupleAccessor fta, FrameTupleReference tuple, IScalarEvaluator eval, IPointable inputVal,
+                        ListAccessor listAccessorConstant, KMeansUtils kMeansUtils, int k, Random rand,
+                        int maxIterations, int totalTupleCount, int partition, int numRounds, double oversamplingFactor)
                         throws HyracksDataException, IOException {
 
                     if (k <= 0 || totalTupleCount <= 0) {
                         return new ClusteringResult(new ArrayList<>(), new int[0]);
                     }
 
-                    System.err.println("performKMeansParallel: starting   k-means|| with "
-                            + totalTupleCount + " total tuples, target k = " + k + ", rounds = " + numRounds
-                            + ", oversampling factor = " + oversamplingFactor);
+                    System.err.println("performKMeansParallel: starting   k-means|| with " + totalTupleCount
+                            + " total tuples, target k = " + k + ", rounds = " + numRounds + ", oversampling factor = "
+                            + oversamplingFactor);
 
                     int[] assignments = new int[totalTupleCount];
 
@@ -1003,8 +1001,8 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                             for (int j = 0; j < tupleCount; j++) {
                                 tuple.reset(fta, j);
                                 eval.evaluate(tuple, inputVal);
-                                if (!ATYPETAGDESERIALIZER.deserialize(
-                                        inputVal.getByteArray()[inputVal.getStartOffset()]).isListType()) {
+                                if (!ATYPETAGDESERIALIZER
+                                        .deserialize(inputVal.getByteArray()[inputVal.getStartOffset()]).isListType()) {
                                     tempIdx++;
                                     continue;
                                 }
@@ -1048,8 +1046,8 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                             for (int j = 0; j < tupleCount; j++) {
                                 tuple.reset(fta, j);
                                 eval.evaluate(tuple, inputVal);
-                                if (!ATYPETAGDESERIALIZER.deserialize(
-                                        inputVal.getByteArray()[inputVal.getStartOffset()]).isListType()) {
+                                if (!ATYPETAGDESERIALIZER
+                                        .deserialize(inputVal.getByteArray()[inputVal.getStartOffset()]).isListType()) {
                                     currentIdx++;
                                     continue;
                                 }
@@ -1093,8 +1091,8 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                         }
                     }
 
-                    System.err.println("Sampling complete: " + candidates.size() + " total candidates (target k = " + k
-                            + ")");
+                    System.err.println(
+                            "Sampling complete: " + candidates.size() + " total candidates (target k = " + k + ")");
 
                     // Step 3: Weight candidates - count how many original points are nearest to each candidate
                     int[] candidateWeights = new int[candidates.size()];
@@ -1112,8 +1110,8 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                         for (int j = 0; j < tupleCount; j++) {
                             tuple.reset(fta, j);
                             eval.evaluate(tuple, inputVal);
-                            if (!ATYPETAGDESERIALIZER.deserialize(
-                                    inputVal.getByteArray()[inputVal.getStartOffset()]).isListType()) {
+                            if (!ATYPETAGDESERIALIZER.deserialize(inputVal.getByteArray()[inputVal.getStartOffset()])
+                                    .isListType()) {
                                 weightIdx++;
                                 continue;
                             }
@@ -1144,16 +1142,15 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
 
                     System.err.println("Weighting complete");
 
-                    
                     List<double[]> weightedCandidates = new ArrayList<>();
                     List<Integer> weightedCandidateWeights = new ArrayList<>();
-                    
+
                     // Reduce duplicates: combine identical/very close candidates and sum their weights
                     for (int i = 0; i < candidates.size(); i++) {
                         if (candidateWeights[i] == 0) {
                             continue; // Skip zero-weight candidates (  filter)
                         }
-                        
+
                         // Check if this candidate is a duplicate of an existing weighted candidate
                         boolean foundDuplicate = false;
                         for (int j = 0; j < weightedCandidates.size(); j++) {
@@ -1165,13 +1162,13 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                                 break;
                             }
                         }
-                        
+
                         if (!foundDuplicate) {
                             weightedCandidates.add(Arrays.copyOf(candidates.get(i), candidates.get(i).length));
                             weightedCandidateWeights.add(candidateWeights[i]);
                         }
                     }
-                    
+
                     System.err.println("Reduced " + candidates.size() + " candidates to " + weightedCandidates.size()
                             + " distinct weighted candidates (after filtering zeros)");
 
@@ -1191,14 +1188,15 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                         System.err.println("No weighted candidates (all filtered), using first centroid only");
                     } else if (weightedCandidates.size() <= k) {
                         // Spark behavior: use weighted candidates and pad to k by sampling from data
-                        System.err.println("Have " + weightedCandidates.size() + " distinct weighted candidates (<= k), padding to k=" + k);
-                        
+                        System.err.println("Have " + weightedCandidates.size()
+                                + " distinct weighted candidates (<= k), padding to k=" + k);
+
                         // Start with weighted candidates (Spark: centersBuf = weightedCandidates.map(_._1).toBuffer)
                         centroids = new ArrayList<>();
                         for (double[] candidate : weightedCandidates) {
                             centroids.add(Arrays.copyOf(candidate, candidate.length));
                         }
-                        
+
                         // Spark: pad with random points from data (data.takeSample)
                         int needed = k - centroids.size();
                         if (needed > 0) {
@@ -1213,7 +1211,7 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                                 }
                                 additionalIndices.add(index);
                             }
-                            
+
                             // Get the additional points
                             in = resetRunFileReader(ctx, sampleUUID, partition);
                             for (int idx : additionalIndices) {
@@ -1234,7 +1232,7 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                                     }
                                 }
                             }
-                            
+
                             // If we still don't have k (edge case: duplicates), pad with perturbed copies
                             while (centroids.size() < k && centroids.size() > 0) {
                                 double[] base = centroids.get(centroids.size() - 1);
@@ -1246,15 +1244,15 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                                 centroids.add(perturbed);
                             }
                         }
-                        
+
                         System.err.println("Padded to " + centroids.size() + " initial centers (target was " + k + ")");
                     } else {
                         // Spark: Normal path - we have more than k weighted candidates
                         // Run weighted k-means++ on weightedCandidates to select exactly k
                         centroids = performWeightedKMeansPlusPlusOnCandidates(weightedCandidates, finalWeights, k, rand,
                                 maxIterations);
-                        System.err.println("Reduced " + weightedCandidates.size() + " weighted candidates to " + centroids.size()
-                                + " final centroids using weighted k-means++");
+                        System.err.println("Reduced " + weightedCandidates.size() + " weighted candidates to "
+                                + centroids.size() + " final centroids using weighted k-means++");
                     }
 
                     // 3. Lloyd's algorithm for refinement using streaming approach
@@ -1392,7 +1390,7 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                             }
                             // Sort by weight (descending)
                             candidateIndices.sort((a, b) -> Integer.compare(weights[b], weights[a]));
-                            
+
                             int remaining = k - result.size();
                             for (int i = 0; i < remaining && i < candidateIndices.size(); i++) {
                                 int idx = candidateIndices.get(i);
@@ -1449,7 +1447,8 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                             }
                         }
 
-                        resultCentroids.add(Arrays.copyOf(candidates.get(selectedIdx), candidates.get(selectedIdx).length));
+                        resultCentroids
+                                .add(Arrays.copyOf(candidates.get(selectedIdx), candidates.get(selectedIdx).length));
                     }
 
                     // 3. Weighted Lloyd's algorithm for refinement
@@ -1512,13 +1511,13 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                     if (resultCentroids.size() < k) {
                         System.err.println("Weighted k-means++ initialization produced only " + resultCentroids.size()
                                 + " centroids, filling gap to reach k=" + k);
-                        
+
                         // Fill gap by selecting additional candidates that are farthest from existing centroids
                         int remaining = k - resultCentroids.size();
                         for (int gap = 0; gap < remaining; gap++) {
                             double maxMinDist = -1.0;
                             int bestCandidateIdx = -1;
-                            
+
                             // Find candidate with maximum minimum distance to existing centroids
                             for (int i = 0; i < candidates.size(); i++) {
                                 // Check if this candidate is already a centroid
@@ -1533,14 +1532,14 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                                 if (isAlreadyCentroid) {
                                     continue;
                                 }
-                                
+
                                 // Find minimum distance to existing centroids
                                 double minDist = Double.POSITIVE_INFINITY;
                                 for (double[] centroid : resultCentroids) {
                                     double dist = calculateDistance(candidates.get(i), centroid);
                                     minDist = Math.min(minDist, dist);
                                 }
-                                
+
                                 // Weight by candidate weight and distance
                                 double weightedScore = weights[i] * minDist;
                                 if (weightedScore > maxMinDist) {
@@ -1548,10 +1547,10 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                                     bestCandidateIdx = i;
                                 }
                             }
-                            
+
                             if (bestCandidateIdx >= 0) {
-                                resultCentroids.add(
-                                        Arrays.copyOf(candidates.get(bestCandidateIdx), candidates.get(bestCandidateIdx).length));
+                                resultCentroids.add(Arrays.copyOf(candidates.get(bestCandidateIdx),
+                                        candidates.get(bestCandidateIdx).length));
                             } else {
                                 // Fallback: if all candidates are duplicates, add a slightly perturbed copy of last centroid
                                 if (resultCentroids.size() > 0) {
@@ -1564,7 +1563,7 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                                 }
                             }
                         }
-                        
+
                         System.err.println("Filled gap in weighted selection: now have " + resultCentroids.size()
                                 + " centroids (target was " + k + ")");
                     }
@@ -1659,8 +1658,9 @@ public final class HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor extends
                     // Perform initial K-means++ on all data to generate initial centroids
                     Random rand = new Random();
                     int maxKMeansIterations = 20;
-                    ClusteringResult initialResult = performInitialKMeansPlusPlus(ctx, in, fta, tuple, eval, inputVal,
-                            listAccessorConstant, kMeansUtils, K, rand, maxKMeansIterations, totalTupleCount, partition);
+                    ClusteringResult initialResult =
+                            performInitialKMeansPlusPlus(ctx, in, fta, tuple, eval, inputVal, listAccessorConstant,
+                                    kMeansUtils, K, rand, maxKMeansIterations, totalTupleCount, partition);
 
                     if (initialResult.centroids.isEmpty()) {
                         System.err.println("No initial centroids generated, cannot perform hierarchical clustering");

--- a/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/operators/VCTreeStaticStructureCreatorOperatorDescriptor.java
+++ b/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/operators/VCTreeStaticStructureCreatorOperatorDescriptor.java
@@ -1144,7 +1144,6 @@ public class VCTreeStaticStructureCreatorOperatorDescriptor extends AbstractOper
                             // Process all tuples for static structure creation
                         }
 
-
                         System.err.println("Finalizing static structure...");
                         // Finalize the structure
                         structureCreator.end();
@@ -1158,12 +1157,11 @@ public class VCTreeStaticStructureCreatorOperatorDescriptor extends AbstractOper
 
                         double[] embedding = new double[vectorDimensions];
                         System.err.println("=== PRINTING STATIC STRUCTURE ===");
-                        VCTreeNavigationUtils.bfsPrintStaticStructure(bufferCache, fileId, 1,
-                                interiorFrameFactory, leafFrameFactory, embedding, /* embeddingPrintLimit */ vectorDimensions);
+                        VCTreeNavigationUtils.bfsPrintStaticStructure(bufferCache, fileId, 1, interiorFrameFactory,
+                                leafFrameFactory, embedding, /* embeddingPrintLimit */ vectorDimensions);
                         System.err.println("=== END STATIC STRUCTURE PRINT ===");
                         System.err
                                 .println("Processed " + totalTuplesProcessed + " tuples for static structure creation");
-
 
                         // Create navigator for static structure access
                         System.err.println("Creating VCTreeStaticStructureNavigator...");

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/frames/VectorClusteringDataFrame.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/frames/VectorClusteringDataFrame.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.hyracks.api.exceptions.HyracksDataException;
-import org.apache.hyracks.data.std.primitive.DoublePointable;
 import org.apache.hyracks.data.std.primitive.FloatPointable;
 import org.apache.hyracks.dataflow.common.comm.io.ArrayTupleBuilder;
 import org.apache.hyracks.dataflow.common.comm.io.ArrayTupleReference;
@@ -95,7 +94,7 @@ public class VectorClusteringDataFrame extends VectorClusteringNSMFrame implemen
         frameTuple.resetByTupleIndex(this, tupleIndex);
         // Distance to centroid is the first field in data records - stored as float
         int distanceOff = frameTuple.getFieldStart(0) + 1;
-// Distance to centroid is the first field in data records - stored as float
+        // Distance to centroid is the first field in data records - stored as float
         double distance = buf.getDouble(distanceOff);
         return distance;
     }

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VCTreeStaticStructureBuilder.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VCTreeStaticStructureBuilder.java
@@ -251,9 +251,10 @@ public class VCTreeStaticStructureBuilder extends AbstractTreeIndexBulkLoader {
                 currentClusterInLevel, currentCentroidInCluster);
 
         try {
-            return TupleUtils.createTuple(new ISerializerDeserializer[] { IntegerSerializerDeserializer.INSTANCE,
-                            DoubleArraySerializerDeserializer.INSTANCE, IntegerSerializerDeserializer.INSTANCE }, centroidId,
-                    embedding, childPageId);
+            return TupleUtils.createTuple(
+                    new ISerializerDeserializer[] { IntegerSerializerDeserializer.INSTANCE,
+                            DoubleArraySerializerDeserializer.INSTANCE, IntegerSerializerDeserializer.INSTANCE },
+                    centroidId, embedding, childPageId);
         } catch (Exception e) {
             System.err.println("ERROR creating entry tuple: " + e.getMessage());
             e.printStackTrace();
@@ -385,8 +386,7 @@ public class VCTreeStaticStructureBuilder extends AbstractTreeIndexBulkLoader {
 
         int nextDirectoryPageId = metaFrame.getMaxPage() + 1;
 
-        LOGGER.debug("Starting directory page ID: {}, processing {} leaf pages",
-                nextDirectoryPageId, leafPages.size());
+        LOGGER.debug("Starting directory page ID: {}, processing {} leaf pages", nextDirectoryPageId, leafPages.size());
 
         // Process each leaf page
         for (int pageIndex = 0; pageIndex < leafPages.size(); pageIndex++) {
@@ -407,8 +407,8 @@ public class VCTreeStaticStructureBuilder extends AbstractTreeIndexBulkLoader {
             LOGGER.debug("Completed updating leaf page {} with {} tuples", pageIndex, tupleCount);
         }
 
-        LOGGER.debug("Updated all {} leaf pages with directory page pointers from {} to {}",
-                leafPages.size(), metaFrame.getMaxPage() + 1, nextDirectoryPageId - 1);
+        LOGGER.debug("Updated all {} leaf pages with directory page pointers from {} to {}", leafPages.size(),
+                metaFrame.getMaxPage() + 1, nextDirectoryPageId - 1);
     }
 
     /**

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/utils/VCTreeNavigationUtils.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/utils/VCTreeNavigationUtils.java
@@ -19,7 +19,9 @@
 package org.apache.hyracks.storage.am.vector.utils;
 
 import java.util.ArrayDeque;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
@@ -38,9 +40,6 @@ import org.apache.hyracks.storage.am.vector.util.VectorUtils;
 import org.apache.hyracks.storage.common.buffercache.IBufferCache;
 import org.apache.hyracks.storage.common.buffercache.ICachedPage;
 import org.apache.hyracks.storage.common.file.BufferedFileHandle;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Utility class for VCTree navigation operations.
@@ -105,7 +104,7 @@ public class VCTreeNavigationUtils {
                     leafEnterFields.put("pageId", currentPageId);
                     leafEnterFields.put("fileId", fileId);
                     logTraversalEvent("leaf_page_enter", leafEnterFields);
-                    
+
                     bestResult = findClosestInLeafPage(queryVector, currentPageId, leafFrame);
                     break; // Found leaf level result
 
@@ -115,7 +114,7 @@ public class VCTreeNavigationUtils {
                     interiorEnterFields.put("pageId", currentPageId);
                     interiorEnterFields.put("fileId", fileId);
                     logTraversalEvent("interior_page_enter", interiorEnterFields);
-                    
+
                     IVectorClusteringInteriorFrame interiorFrame =
                             (IVectorClusteringInteriorFrame) interiorFrameFactory.createFrame();
                     interiorFrame.setPage(page);
@@ -124,13 +123,13 @@ public class VCTreeNavigationUtils {
                         throw HyracksDataException.create(ErrorCode.ILLEGAL_STATE,
                                 "No valid centroid found in interior cluster");
                     }
-                    
+
                     Map<String, Object> interiorDescendFields = new HashMap<>();
                     interiorDescendFields.put("pageId", currentPageId);
                     interiorDescendFields.put("selectedChildPageId", nextPageId);
                     interiorDescendFields.put("fileId", fileId);
                     logTraversalEvent("interior_descend", interiorDescendFields);
-                    
+
                     currentPageId = nextPageId;
                 }
 
@@ -214,12 +213,12 @@ public class VCTreeNavigationUtils {
         sb.append("{\"event\":\"");
         sb.append(eventType);
         sb.append("\"");
-        
+
         for (Map.Entry<String, Object> entry : fields.entrySet()) {
             sb.append(",\"");
             sb.append(entry.getKey());
             sb.append("\":");
-            
+
             Object value = entry.getValue();
             if (value instanceof String) {
                 sb.append("\"");
@@ -233,7 +232,7 @@ public class VCTreeNavigationUtils {
                 sb.append(value);
             }
         }
-        
+
         sb.append("}");
         System.err.println(sb.toString());
     }
@@ -309,7 +308,7 @@ public class VCTreeNavigationUtils {
             searchSelectFields.put("bestDistance", bestDistance);
             searchSelectFields.put("candidatesProcessed", candidatesProcessed);
             logTraversalEvent("leaf_search_select", searchSelectFields);
-            
+
             return ClusterSearchResult.create(pageId, bestClusterIndex, bestCentroid, bestDistance, bestCentroidId);
         }
         // TODO : SOME RETURN EMPTY
@@ -381,8 +380,8 @@ public class VCTreeNavigationUtils {
         return bestChildPageId;
     }
 
-    private static int findClosestInInteriorPage(double[] queryVector,
-                                                 IVectorClusteringInteriorFrame interiorFrame) throws HyracksDataException {
+    private static int findClosestInInteriorPage(double[] queryVector, IVectorClusteringInteriorFrame interiorFrame)
+            throws HyracksDataException {
 
         int tupleCount = interiorFrame.getTupleCount();
         double bestDistance = Double.MAX_VALUE;
@@ -419,7 +418,6 @@ public class VCTreeNavigationUtils {
      * @param tuple Leaf frame tuple
      * @return Centroid vector
      */
-
 
     /**
      * Perform a breadth-first traversal of the static structure starting at root and print
@@ -479,13 +477,13 @@ public class VCTreeNavigationUtils {
                             String centroidStr = formatCentroid(centroid, printLimit);
                             String distStr = computeDistanceString(queryVector, centroid);
 
-                            System.err.println("tuple=" + i + " | cid=" + cid + " | centroidId=" + centroidId
-                                    + " | centroid=" + centroidStr + " | dist=" + distStr + " | metadata="
-                                    + metadataPtr);
+                            System.err.println(
+                                    "tuple=" + i + " | cid=" + cid + " | centroidId=" + centroidId + " | centroid="
+                                            + centroidStr + " | dist=" + distStr + " | metadata=" + metadataPtr);
                             processedTuples++;
                         } catch (Exception e) {
-                            System.err.println("ERROR processing leaf tuple " + i + " on page " + currentPageId
-                                    + ": " + e.getMessage());
+                            System.err.println("ERROR processing leaf tuple " + i + " on page " + currentPageId + ": "
+                                    + e.getMessage());
                         }
                     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Code cleanup across vector clustering operators/utilities: reflowed method signatures and logs, minor whitespace fixes, and removal of an unused import.
> 
> - **Runtime**:
>   - `HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor`: reformat method signatures and log messages; minor whitespace and line-wrap adjustments.
>   - `VCTreeStaticStructureCreatorOperatorDescriptor`: wrap long method calls/logs; minor whitespace cleanup.
> - **Storage (Hyracks)**:
>   - `VectorClusteringDataFrame`: remove unused import; align comment; minor whitespace.
>   - `VCTreeStaticStructureBuilder`: compact log statements; formatting tweaks.
>   - `VCTreeNavigationUtils`: reorder imports; reformat methods/logging; whitespace cleanup.
> - **Metadata**:
>   - `SecondaryVectorOperationsHelper`: minor whitespace cleanup around field copy logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c699ecb917847fd00d6e439a0a22bffb6996c665. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->