### PR TITLE
static structure moved to constructor

### DIFF
--- a/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/operators/VCTreeSortedDataBulkLoaderOperatorDescriptor.java
+++ b/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/operators/VCTreeSortedDataBulkLoaderOperatorDescriptor.java
@@ -22,10 +22,8 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 
 import org.apache.asterix.om.base.ADouble;
 import org.apache.asterix.om.base.AInt32;
@@ -68,13 +66,9 @@ import org.apache.hyracks.storage.am.lsm.common.impls.VirtualBufferCache;
 import org.apache.hyracks.storage.am.lsm.vector.impls.LSMVCTree;
 import org.apache.hyracks.storage.am.lsm.vector.impls.LSMVCTreeBulkLoader;
 import org.apache.hyracks.storage.am.lsm.vector.utils.LSMVCTreeUtils;
-import org.apache.hyracks.storage.am.vector.frames.VectorClusteringInteriorFrameFactory;
-import org.apache.hyracks.storage.am.vector.frames.VectorClusteringLeafFrameFactory;
 import org.apache.hyracks.storage.common.LocalResource;
 import org.apache.hyracks.storage.common.buffercache.HeapBufferAllocator;
 import org.apache.hyracks.storage.common.buffercache.IBufferCache;
-import org.apache.hyracks.storage.common.buffercache.ICachedPage;
-import org.apache.hyracks.storage.common.file.BufferedFileHandle;
 
 /**
  * Bulk loader operator that processes sorted tuples from ExternalSortOperatorDescriptor.
@@ -152,12 +146,6 @@ public class VCTreeSortedDataBulkLoaderOperatorDescriptor extends AbstractSingle
         private LSMVCTree lsmvcTree;
         private LSMVCTreeBulkLoader bulkLoader;
 
-        // Static structure navigation components
-        private IBufferCache bufferCache;
-        private int staticStructureFileId;
-        private VectorClusteringInteriorFrameFactory interiorFrameFactory;
-        private VectorClusteringLeafFrameFactory leafFrameFactory;
-
         // Centroid tracking state
         private int currentCentroidId = -1;
         private int tupleCountForCurrentCentroid = 0;
@@ -198,11 +186,8 @@ public class VCTreeSortedDataBulkLoaderOperatorDescriptor extends AbstractSingle
                 // Initialize LSMVCTree
                 initializeLSMVCTree();
 
-                // Initialize bulk loader first (needed for page copying)
+                // Initialize bulk loader (static structure copying happens in constructor)
                 initializeBulkLoader();
-
-                // Navigate existing static structure and copy pages
-                navigateExistingStaticStructure();
 
                 System.err.println("VCTreeSortedDataBulkLoader opened successfully");
             } catch (Exception e) {
@@ -284,173 +269,6 @@ public class VCTreeSortedDataBulkLoaderOperatorDescriptor extends AbstractSingle
         }
 
         /**
-         * Navigate existing static structure file using level order traversal and copy pages.
-         * The static structure was already created by VCTreeStaticStructureCreatorOperatorDescriptor.
-         * 
-         * @throws HyracksDataException if navigation fails
-         */
-        private void navigateExistingStaticStructure() throws HyracksDataException {
-            try {
-                System.err.println("=== NAVIGATING EXISTING STATIC STRUCTURE WITH LEVEL ORDER TRAVERSAL ===");
-
-                // Get the static structure file path
-                FileReference indexPathRef = getIndexFilePath();
-                if (indexPathRef == null) {
-                    throw HyracksDataException.create(org.apache.hyracks.api.exceptions.ErrorCode.ILLEGAL_STATE,
-                            "Could not determine index path for static structure navigation");
-                }
-
-                // Create static structure file path
-                FileReference staticStructureFile = indexPathRef.getChild(".static_structure_vctree");
-                System.err.println("Static structure file path: " + staticStructureFile);
-
-                // Check if static structure file exists
-                IIOManager ioManager = ctx.getJobletContext().getServiceContext().getIoManager();
-                if (!ioManager.exists(staticStructureFile)) {
-                    throw HyracksDataException.create(org.apache.hyracks.api.exceptions.ErrorCode.FILE_DOES_NOT_EXIST,
-                            "Static structure file does not exist: " + staticStructureFile);
-                }
-
-                // Initialize navigation components
-                initializeNavigationComponents(staticStructureFile);
-
-                // Perform level order traversal and page copying
-                copyPagesInLevelOrder();
-
-                System.err.println("✅ Static structure navigation and page copying completed successfully");
-
-            } catch (Exception e) {
-                System.err.println("ERROR: Failed to navigate existing static structure: " + e.getMessage());
-                e.printStackTrace();
-                throw HyracksDataException.create(e);
-            }
-        }
-
-        /**
-         * Copy all pages in level-order using BFS traversal.
-         * This follows the same pattern as VCTreeStaticStructureNavigator.copyPagesInLevelOrder().
-         * 
-         * @throws HyracksDataException if any error occurs during traversal
-         */
-        private void copyPagesInLevelOrder() throws HyracksDataException {
-            try {
-                System.err.println("=== STARTING LEVEL ORDER PAGE COPYING ===");
-                Queue<Integer> pageQueue = new LinkedList<>();
-                pageQueue.offer(1); // Start with root page (page ID 0)
-
-                int pagesProcessed = 0;
-
-                for (int pageId = 1; pageId <= 8; pageId++) {
-                    ICachedPage sourcePage =
-                            bufferCache.pin(BufferedFileHandle.getDiskPageId(staticStructureFileId, pageId));
-                    bulkLoader.copyPage(sourcePage);
-                    bufferCache.unpin(sourcePage);
-                }
-
-                //                while (!pageQueue.isEmpty()) {
-                //                    int currentPageId = pageQueue.poll();
-                //
-                //                    // Pin and copy the current page
-                //                    ICachedPage sourcePage =
-                //                    try {
-                //                        sourcePage.acquireReadLatch();
-                //
-                //                        // Copy the page using bulk loader
-                //                        if (bulkLoader != null) {
-                //                            bulkLoader.copyPage(sourcePage);
-                //                        }
-                //                        pagesProcessed++;
-                //
-                //                        System.err.println("Copied page " + currentPageId + " (total processed: " + pagesProcessed + ")");
-                //
-                //                        // Check if this is an interior page (has children)
-                //                        org.apache.hyracks.storage.am.vector.frames.VectorClusteringInteriorFrame interiorFrame =
-                //                                (org.apache.hyracks.storage.am.vector.frames.VectorClusteringInteriorFrame) interiorFrameFactory.createFrame();
-                //                        interiorFrame.setPage(sourcePage);
-                //
-                //                        if (!interiorFrame.isLeaf()) {
-                //                            // Add all child pages to queue
-                //                            int tupleCount = interiorFrame.getTupleCount();
-                //                            for (int i = 0; i < tupleCount; i++) {
-                //                                int childPageId = interiorFrame.getChildPageId(i);
-                //                                if (childPageId > 0) {
-                //                                    pageQueue.offer(childPageId);
-                //                                    System.err.println("Added child page " + childPageId + " to queue");
-                //                                }
-                //                            }
-                //                        }
-                //
-                //                    } finally {
-                //                        sourcePage.releaseReadLatch();
-                //                        bufferCache.unpin(sourcePage);
-                //                    }
-                //                }
-
-                System.err.println("✅ Level-order page copying completed. Total pages processed: " + pagesProcessed);
-
-            } catch (Exception e) {
-                System.err.println("ERROR: Failed to copy pages in level order: " + e.getMessage());
-                e.printStackTrace();
-                throw HyracksDataException.create(e);
-            }
-        }
-
-        /**
-         * Initialize navigation components for static structure traversal.
-         * 
-         * @param staticStructureFile File reference to the static structure file
-         * @throws HyracksDataException if initialization fails
-         */
-        private void initializeNavigationComponents(FileReference staticStructureFile) throws HyracksDataException {
-            try {
-                System.err.println("=== INITIALIZING NAVIGATION COMPONENTS ===");
-
-                // Get buffer cache
-                bufferCache = ((org.apache.asterix.common.api.INcApplicationContext) ctx.getJobletContext()
-                        .getServiceContext().getApplicationContext()).getBufferCache();
-
-                // Open static structure file
-                staticStructureFileId = bufferCache.openFile(staticStructureFile);
-
-                // Configure VCTree frame factories
-                configureVCTreeFrameFactories();
-
-                System.err.println("✅ Navigation components initialized successfully");
-                System.err.println("  - Static structure file ID: " + staticStructureFileId);
-                System.err.println("  - Buffer cache: " + (bufferCache != null ? "OK" : "NULL"));
-
-            } catch (Exception e) {
-                System.err.println("ERROR: Failed to initialize navigation components: " + e.getMessage());
-                e.printStackTrace();
-                throw HyracksDataException.create(e);
-            }
-        }
-
-        /**
-         * Configure VCTree frame factories for static structure navigation.
-         * 
-         * @throws HyracksDataException if configuration fails
-         */
-        private void configureVCTreeFrameFactories() throws HyracksDataException {
-            try {
-                System.err.println("=== CONFIGURING VCTREE FRAME FACTORIES ===");
-
-                // Initialize frame factories
-                interiorFrameFactory = new VectorClusteringInteriorFrameFactory(vectorDimensions);
-                leafFrameFactory = new VectorClusteringLeafFrameFactory(null, vectorDimensions);
-
-                System.err.println("✅ VCTree frame factories configured successfully");
-                System.err.println("  - Interior frame factory: " + (interiorFrameFactory != null ? "OK" : "NULL"));
-                System.err.println("  - Leaf frame factory: " + (leafFrameFactory != null ? "OK" : "NULL"));
-
-            } catch (Exception e) {
-                System.err.println("ERROR: Failed to configure VCTree frame factories: " + e.getMessage());
-                e.printStackTrace();
-                throw HyracksDataException.create(e);
-            }
-        }
-
-        /**
          * Initialize bulk loader for data loading.
          * 
          * @throws HyracksDataException if bulk loader initialization fails
@@ -472,8 +290,9 @@ public class VCTreeSortedDataBulkLoaderOperatorDescriptor extends AbstractSingle
                                 DoubleArraySerializerDeserializer.INSTANCE // primary key
                         };
 
-                // Create LSMVCTreeBulkLoader
-                bulkLoader = lsmvcTree.createBulkLoader(numLeafCentroids, firstLeafCentroidId, dataFrameSerdes);
+                // Create LSMVCTreeBulkLoader with static structure filename
+                bulkLoader = lsmvcTree.createBulkLoader(numLeafCentroids, firstLeafCentroidId, dataFrameSerdes,
+                        ".static_structure_vctree");
 
                 System.err.println("✅ Bulk loader initialized successfully");
 

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VCTreeBulkLoader.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VCTreeBulkLoader.java
@@ -18,11 +18,13 @@
  */
 package org.apache.hyracks.storage.am.vector.impls;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.hyracks.api.dataflow.value.ISerializerDeserializer;
 import org.apache.hyracks.api.exceptions.HyracksDataException;
+import org.apache.hyracks.api.io.FileReference;
 import org.apache.hyracks.data.std.primitive.LongPointable;
 import org.apache.hyracks.dataflow.common.data.accessors.ITupleReference;
 import org.apache.hyracks.dataflow.common.data.marshalling.DoubleSerializerDeserializer;
@@ -43,7 +45,7 @@ import org.apache.hyracks.storage.common.file.BufferedFileHandle;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class VCTreeBulkLoder extends AbstractTreeIndexBulkLoader {
+public class VCTreeBulkLoader extends AbstractTreeIndexBulkLoader {
     private static final Logger LOGGER = LogManager.getLogger();
     private int firstLeafCentroidId; // ID of the first leaf centroid
     private int numLeafCentroid; // Total number of leaf centroids
@@ -64,10 +66,10 @@ public class VCTreeBulkLoder extends AbstractTreeIndexBulkLoader {
     private final VectorClusteringTree vcTreeIndex;
     private int firstDirectoryPageId;
 
-    public VCTreeBulkLoder(float fillFactor, IPageWriteCallback callback, VectorClusteringTree vectorTree,
+    public VCTreeBulkLoader(float fillFactor, IPageWriteCallback callback, VectorClusteringTree vectorTree,
             ITreeIndexFrame leafFrame, ITreeIndexFrame dataFrame, IBufferCacheWriteContext writeContext,
-            int numLeafCentroid, int firstLeafCentroidId, ISerializerDeserializer[] dataFrameSerds)
-            throws HyracksDataException {
+            int numLeafCentroid, int firstLeafCentroidId, ISerializerDeserializer[] dataFrameSerds,
+            String staticStructureFileName) throws HyracksDataException {
         super(0, callback, vectorTree, leafFrame, writeContext);
         this.numLeafCentroid = numLeafCentroid;
         this.firstLeafCentroidId = firstLeafCentroidId;
@@ -84,6 +86,60 @@ public class VCTreeBulkLoder extends AbstractTreeIndexBulkLoader {
         this.dataFrameTupleWriter = currentDataFrame.getTupleWriter();
         this.directoryFrameTupleWriter = currentDirectoryFrame.getTupleWriter();
         this.currentLeafClusterIndex = 0;
+
+        // Copy static structure if filename provided
+        if (staticStructureFileName != null) {
+            copyStaticStructure(staticStructureFileName);
+        }
+    }
+
+    /**
+     * Copy static structure from existing file into this bulk loader.
+     * 
+     * @param staticStructureFileName Name of the static structure file (relative to index file directory)
+     * @throws HyracksDataException if file doesn't exist or copying fails
+     */
+    private void copyStaticStructure(String staticStructureFileName) throws HyracksDataException {
+        try {
+            // Derive static structure file path from index file
+            FileReference indexFileRef = treeIndex.getFileReference();
+            FileReference staticStructureFileRef = indexFileRef.getParent().getChild(staticStructureFileName);
+
+            // Check if file exists
+            File staticStructureFile = new File(staticStructureFileRef.getAbsolutePath());
+            if (!staticStructureFile.exists()) {
+                throw HyracksDataException.create(org.apache.hyracks.api.exceptions.ErrorCode.FILE_DOES_NOT_EXIST,
+                        "Static structure file does not exist: " + staticStructureFileRef.getAbsolutePath());
+            }
+
+            LOGGER.debug("Copying static structure from: {}", staticStructureFileRef.getAbsolutePath());
+
+            // Open static structure file
+            int staticStructureFileId = bufferCache.openFile(staticStructureFileRef);
+
+            try {
+                // Copy pages 1-8 in level order
+                for (int pageId = 1; pageId <= 8; pageId++) {
+                    ICachedPage sourcePage =
+                            bufferCache.pin(BufferedFileHandle.getDiskPageId(staticStructureFileId, pageId));
+                    try {
+                        copyPage(sourcePage);
+                    } finally {
+                        bufferCache.unpin(sourcePage);
+                    }
+                }
+
+                LOGGER.debug("Successfully copied static structure pages 1-8");
+            } finally {
+                // Close static structure file
+                bufferCache.closeFile(staticStructureFileId);
+            }
+
+        } catch (HyracksDataException e) {
+            throw e;
+        } catch (Exception e) {
+            throw HyracksDataException.create(e);
+        }
     }
 
     public void copyPage(ICachedPage sourcePage) throws HyracksDataException {

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VCTreeStaticStructureNavigator.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VCTreeStaticStructureNavigator.java
@@ -150,7 +150,7 @@ public class VCTreeStaticStructureNavigator {
      * @param bulkLoader VCTreeBulkLoder to copy pages to
      * @throws HyracksDataException if any error occurs during traversal
      */
-    public void copyPagesInLevelOrder(VCTreeBulkLoder bulkLoader) throws HyracksDataException {
+    public void copyPagesInLevelOrder(VCTreeBulkLoader bulkLoader) throws HyracksDataException {
         LOGGER.debug("Starting level-order page copying from root page {}", rootPageId);
 
         Queue<Integer> pageQueue = new LinkedList<>();

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTree.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTree.java
@@ -134,10 +134,12 @@ public class VectorClusteringTree extends AbstractTreeIndex {
         return 0;
     }
 
-    public VCTreeBulkLoder createBulkLoader(NoOpPageWriteCallback instance, int numLeafCentroid,
-            int firstLeafCentroidId, ISerializerDeserializer[] dataFrameSerdes) throws HyracksDataException {
-        return new VCTreeBulkLoder(0, instance, this, leafFrameFactory.createFrame(), dataFrameFactory.createFrame(),
-                DefaultBufferCacheWriteContext.INSTANCE, numLeafCentroid, firstLeafCentroidId, dataFrameSerdes);
+    public VCTreeBulkLoader createBulkLoader(NoOpPageWriteCallback instance, int numLeafCentroid,
+            int firstLeafCentroidId, ISerializerDeserializer[] dataFrameSerdes, String staticStructureFileName)
+            throws HyracksDataException {
+        return new VCTreeBulkLoader(0, instance, this, leafFrameFactory.createFrame(), dataFrameFactory.createFrame(),
+                DefaultBufferCacheWriteContext.INSTANCE, numLeafCentroid, firstLeafCentroidId, dataFrameSerdes,
+                staticStructureFileName);
     }
 
     @Override
@@ -156,10 +158,10 @@ public class VectorClusteringTree extends AbstractTreeIndex {
         dataFrameSerds[2] = DoubleArraySerializerDeserializer.INSTANCE; // vector
         dataFrameSerds[3] = IntegerSerializerDeserializer.INSTANCE; // primary key
 
-        return new VCTreeBulkLoder(fillFactor, callback, this, leafFrameFactory.createFrame(),
+        return new VCTreeBulkLoader(fillFactor, callback, this, leafFrameFactory.createFrame(),
                 dataFrameFactory.createFrame(), DefaultBufferCacheWriteContext.INSTANCE, 4, // numLeafCentroid
                 0, // firstLeafCentroidId
-                dataFrameSerds);
+                dataFrameSerds, null); // staticStructureFileName - null for default createBulkLoader
     }
 
     public VCTreeStaticStructureBuilder createStaticStructureBuilder(int numLevels, List<Integer> clustersPerLevel,

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTree.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTree.java
@@ -199,11 +199,15 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
     }
 
     public LSMVCTreeBulkLoader createBulkLoader(int numLeafCentroids, int firstLeafCentroidId,
-            ISerializerDeserializer[] dataFrameSerdes) throws HyracksDataException {
+            ISerializerDeserializer[] dataFrameSerdes, String staticStructureFileName) throws HyracksDataException {
         AbstractLSMIndexOperationContext opCtx = createOpContext(NoOpIndexAccessParameters.INSTANCE);
         LSMComponentFileReferences componentFileRefs = fileManager.getRelFlushFileReference();
         LoadOperation loadOp =
                 new LoadOperation(componentFileRefs, ioOpCallback, getIndexIdentifier(), new HashMap<>());
+        // Add static structure filename to operation parameters
+        if (staticStructureFileName != null) {
+            loadOp.getParameters().put("staticStructureFileName", staticStructureFileName);
+        }
         ILSMDiskComponent diskComponent = createDiskComponent(bulkLoadComponentFactory,
                 componentFileRefs.getInsertIndexFileReference(), null, null, true);
         loadOp.setNewComponent(diskComponent);

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeBulkLoader.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeBulkLoader.java
@@ -25,13 +25,14 @@ import org.apache.hyracks.dataflow.common.data.accessors.ITupleReference;
 import org.apache.hyracks.storage.am.lsm.common.api.ILSMDiskComponent;
 import org.apache.hyracks.storage.am.lsm.common.api.ILSMIOOperation;
 import org.apache.hyracks.storage.am.lsm.common.api.ILSMIndexOperationContext;
-import org.apache.hyracks.storage.am.vector.impls.VCTreeBulkLoder;
+import org.apache.hyracks.storage.am.lsm.common.impls.IChainedComponentBulkLoader;
+import org.apache.hyracks.storage.am.vector.impls.VCTreeBulkLoader;
 import org.apache.hyracks.storage.common.buffercache.ICachedPage;
 import org.apache.hyracks.storage.common.buffercache.NoOpPageWriteCallback;
 
-public class LSMVCTreeBulkLoader {
+public class LSMVCTreeBulkLoader implements IChainedComponentBulkLoader {
     private final LSMVCTree lsmvcTree;
-    private final VCTreeBulkLoder bulkLoader;
+    private final VCTreeBulkLoader bulkLoader;
     private final ILSMIndexOperationContext opCtx;
     private boolean failed = false;
 
@@ -40,26 +41,30 @@ public class LSMVCTreeBulkLoader {
             NoOpPageWriteCallback instance) throws HyracksDataException {
         this.lsmvcTree = lsmvcTree;
         this.opCtx = opCtx;
-        this.bulkLoader = ((LSMVCTreeDiskComponent) opCtx.getIoOperation().getNewComponent())
-                .createBulkLoader(numLeafCentroid, firstLeafCentroidId, dataFrameSerdes, instance);
+        // Extract static structure filename from operation parameters
+        String staticStructureFileName = (String) opCtx.getIoOperation().getParameters().get("staticStructureFileName");
+        this.bulkLoader = ((LSMVCTreeDiskComponent) opCtx.getIoOperation().getNewComponent()).createBulkLoader(
+                numLeafCentroid, firstLeafCentroidId, dataFrameSerdes, instance, staticStructureFileName);
     }
 
     public ILSMDiskComponent getComponent() {
         return opCtx.getIoOperation().getNewComponent();
     }
 
-    public void add(ITupleReference tuple) throws HyracksDataException {
-        try {
-            bulkLoader.add(tuple);
-        } catch (Throwable th) {
-            fail(th);
-            throw th;
-        }
+    public ITupleReference add(ITupleReference tuple) throws HyracksDataException {
+        bulkLoader.add(tuple);
+        return tuple;
+    }
+
+    @Override
+    public ITupleReference delete(ITupleReference tuple) throws HyracksDataException {
+        // TODO : implement delete for LSMVCTreeBulkLoader Hongyu?
+        return null;
     }
 
     public void next() throws HyracksDataException {
         try {
-            ((VCTreeBulkLoder) bulkLoader).loadToNextLeafCluster();
+            ((VCTreeBulkLoader) bulkLoader).loadToNextLeafCluster();
         } catch (Throwable th) {
             fail(th);
             throw th;
@@ -68,7 +73,7 @@ public class LSMVCTreeBulkLoader {
 
     public void copyPage(ICachedPage page) throws HyracksDataException {
         try {
-            ((VCTreeBulkLoder) bulkLoader).copyPage(page);
+            ((VCTreeBulkLoader) bulkLoader).copyPage(page);
         } catch (Throwable th) {
             fail(th);
             throw th;
@@ -98,6 +103,16 @@ public class LSMVCTreeBulkLoader {
         } finally {
             lsmvcTree.getIOOperationCallback().completed(opCtx.getIoOperation());
         }
+    }
+
+    @Override
+    public void cleanupArtifacts() throws HyracksDataException {
+
+    }
+
+    @Override
+    public void writeFailed(ICachedPage page, Throwable failure) {
+        throw new UnsupportedOperationException();
     }
 
     public boolean hasFailed() {

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeDiskComponent.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeDiskComponent.java
@@ -37,7 +37,7 @@ import org.apache.hyracks.storage.am.lsm.common.impls.AbstractLSMIndex;
 import org.apache.hyracks.storage.am.lsm.common.impls.ChainedLSMDiskComponentBulkLoader;
 import org.apache.hyracks.storage.am.lsm.common.impls.IChainedComponentBulkLoader;
 import org.apache.hyracks.storage.am.lsm.common.impls.LSMIndexBulkLoader;
-import org.apache.hyracks.storage.am.vector.impls.VCTreeBulkLoder;
+import org.apache.hyracks.storage.am.vector.impls.VCTreeBulkLoader;
 import org.apache.hyracks.storage.am.vector.impls.VCTreeLoader;
 import org.apache.hyracks.storage.am.vector.impls.VCTreeStaticStructureBuilder;
 import org.apache.hyracks.storage.am.vector.impls.VectorClusteringTree;
@@ -233,10 +233,25 @@ public class LSMVCTreeDiskComponent extends AbstractLSMDiskComponent {
                 maxEntriesPerPage, instance);
     }
 
-    public VCTreeBulkLoder createBulkLoader(int numLeafCentroid, int firstLeafCentroidId,
+    public VCTreeBulkLoader createBulkLoader(int numLeafCentroid, int firstLeafCentroidId,
             ISerializerDeserializer[] dataFrameSerdes, IPageWriteCallback callback) throws HyracksDataException {
+        // Extract static structure filename from operation parameters if available
+        String staticStructureFileName = null;
+        // Note: This method doesn't have access to operation, so staticStructureFileName will be passed
+        // through from the caller via VectorClusteringTree.createBulkLoader()
         return getIndex().createBulkLoader((NoOpPageWriteCallback) callback, numLeafCentroid, firstLeafCentroidId,
-                dataFrameSerdes);
+                dataFrameSerdes, staticStructureFileName);
+    }
+
+    /**
+     * Create bulk loader with static structure filename support.
+     * This overloaded method allows passing the static structure filename directly.
+     */
+    public VCTreeBulkLoader createBulkLoader(int numLeafCentroid, int firstLeafCentroidId,
+            ISerializerDeserializer[] dataFrameSerdes, IPageWriteCallback callback, String staticStructureFileName)
+            throws HyracksDataException {
+        return getIndex().createBulkLoader((NoOpPageWriteCallback) callback, numLeafCentroid, firstLeafCentroidId,
+                dataFrameSerdes, staticStructureFileName);
     }
 
     public boolean isStaticStructure() {

--- a/hyracks-fullstack/hyracks/hyracks-test-support/src/main/java/org/apache/hyracks/storage/am/vector/VectorTreeTestUtils.java
+++ b/hyracks-fullstack/hyracks/hyracks-test-support/src/main/java/org/apache/hyracks/storage/am/vector/VectorTreeTestUtils.java
@@ -128,8 +128,8 @@ public class VectorTreeTestUtils extends TreeIndexTestUtils {
                         new UTF8StringSerializerDeserializer() // primary key
                 };
 
-        LSMVCTreeBulkLoader bulkLoader =
-                ((LSMVCTree) ctx.getIndex()).createBulkLoader(numLeafCentroids, firstLeafCentroidId, dataFrameSerdes);
+        LSMVCTreeBulkLoader bulkLoader = ((LSMVCTree) ctx.getIndex()).createBulkLoader(numLeafCentroids,
+                firstLeafCentroidId, dataFrameSerdes, ".static_structure_vctree");
 
         for (int pageId = 1; pageId <= maxPageId; pageId++) {
             ICachedPage sourcePage = vcTreeAccessor.getCachedPage(pageId);


### PR DESCRIPTION
# Change List - Commit fb4ea99d5f7f50a981eebfafe61cdd1ec6516669

**Commit:** fb4ea99d5f7f50a981eebfafe61cdd1ec6516669  
**Author:** Calvin Thomas Dani <55625081+calvin-dani@users.noreply.github.com>  
**Date:** Fri Oct 31 16:45:41 2025 -0700  
**Message:** clean up (#46)

## Files Changed

**Statistics:** 6 files changed, 75 insertions(+), 81 deletions(-)

### Modified Files:
1. `asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/utils/SecondaryVectorOperationsHelper.java`
2. `asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/operators/HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor.java`
3. `asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/operators/VCTreeStaticStructureCreatorOperatorDescriptor.java`
4. `hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/frames/VectorClusteringDataFrame.java`
5. `hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VCTreeStaticStructureBuilder.java`
6. `hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/utils/VCTreeNavigationUtils.java`

## Detailed Changes

### 1. SecondaryVectorOperationsHelper.java
- **Change:** Removed trailing blank line
- **Location:** Line 320 (after outputTypeTraits initialization)

### 2. HierarchicalKMeansPlusPlusCentroidsOperatorDescriptor.java (96 lines modified)
This file received the most extensive cleanup changes:

#### Code Formatting Improvements:
- **Line 433:** Removed trailing whitespace
- **Line 942-945:** Method signature reformatting:
  - Split long method parameters across multiple lines
  - Aligned parameter lists consistently
- **Line 956-959:** `performKMeansParallel` method signature reformatting:
  - Reformatted parameters for better readability
  - Consistent indentation and line breaks
- **Lines 965-967:** System.err.println statement reformatting:
  - Split long print statements across multiple lines
  - Improved readability
- **Lines 1004-1006, 1049-1051, 1113-1115:** Method call reformatting:
  - Reformatted `ATYPETAGDESERIALIZER.deserialize()` calls
  - Split across lines for better readability
- **Line 1094-1095:** System.err.println reformatting:
  - Split long print statement across multiple lines
- **Lines 1144-1148:** Removed blank lines, improved spacing
- **Lines 1165, 1169, 1175:** Removed trailing whitespace
- **Line 1191:** System.err.println reformatting for better line length
- **Line 1214:** Removed trailing whitespace
- **Line 1235:** Removed trailing whitespace
- **Line 1247:** Removed trailing whitespace
- **Line 1250-1251:** System.err.println reformatting:
  - Split across multiple lines
- **Line 1393:** Removed trailing whitespace
- **Line 1450-1451:** Method call reformatting:
  - Split `Arrays.copyOf()` call across lines
- **Line 1514:** Removed trailing whitespace
- **Lines 1516, 1521:** Removed trailing whitespace
- **Lines 1535, 1539, 1544:** Removed trailing whitespace
- **Line 1550-1551:** Method call reformatting:
  - Split `Arrays.copyOf()` call across lines
- **Line 1566:** Removed trailing whitespace
- **Lines 1661-1663:** Method call reformatting:
  - Reformatted `performInitialKMeansPlusPlus()` call across multiple lines

### 3. VCTreeStaticStructureCreatorOperatorDescriptor.java
- **Line 1147:** Removed trailing blank line
- **Lines 1160-1161:** Method call reformatting:
  - Reformatted `bfsPrintStaticStructure()` parameters across multiple lines
- **Line 1165:** Removed trailing blank line

### 4. VectorClusteringDataFrame.java
- **Line 32:** Removed unused import: `org.apache.hyracks.data.std.primitive.DoublePointable`
- **Line 97:** Fixed comment indentation:
  - Moved comment from line 98 to proper position on line 97

### 5. VCTreeStaticStructureBuilder.java
- **Lines 254-257:** Method call reformatting:
  - Reformatted `TupleUtils.createTuple()` call:
    - Split array parameter across multiple lines
    - Improved indentation and alignment
- **Lines 389-390:** Logging statement reformatting:
  - Reformatted `LOGGER.debug()` call across multiple lines
- **Lines 410-411:** Logging statement reformatting:
  - Reformatted `LOGGER.debug()` call across multiple lines

### 6. VCTreeNavigationUtils.java (36 lines modified)

#### Import Organization:
- **Lines 22-27:** Moved imports (`HashMap`, `Map`) to proper location:
  - Previously scattered between other imports
  - Now grouped together at top with other `java.util` imports

#### Code Formatting Improvements:
- **Line 107:** Removed trailing whitespace
- **Line 117:** Removed trailing whitespace
- **Line 126:** Removed trailing whitespace
- **Line 132:** Removed trailing whitespace
- **Line 216:** Removed trailing whitespace
- **Line 221:** Removed trailing whitespace
- **Line 235:** Removed trailing whitespace
- **Line 312:** Removed trailing whitespace
- **Lines 383-384:** Method signature reformatting:
  - Reformatted `findClosestInInteriorPage()` signature across multiple lines
- **Line 422:** Removed trailing blank line (after method documentation comment)
- **Lines 480-481:** System.err.println reformatting:
  - Reformatted long print statement across multiple lines

## Summary

This commit is a **code cleanup** focused on:

1. **Code formatting consistency:**
   - Removed trailing whitespace throughout
   - Removed unnecessary blank lines
   - Standardized method parameter formatting (multi-line splits for long signatures)

2. **Import organization:**
   - Fixed import order in `VCTreeNavigationUtils.java`
   - Removed unused import in `VectorClusteringDataFrame.java`

3. **Readability improvements:**
   - Split long method calls and print statements across multiple lines
   - Consistent indentation and alignment
   - Better code structure without changing functionality

**Impact:** No functional changes - purely cosmetic/formatting improvements to enhance code maintainability and readability.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves static-structure page copying into `VCTreeBulkLoader` (via filename), updates APIs across vector/LSM layers, and simplifies the runtime bulk-load operator.
> 
> - **Vector storage (btree layer)**:
>   - Rename and expand `VCTreeBulkLoder` to `VCTreeBulkLoader` with new ctor param `staticStructureFileName` and internal `copyStaticStructure()` to import static pages.
>   - Add `copyPage()` and cluster-loading flow; adjust `VCTreeStaticStructureNavigator.copyPagesInLevelOrder` to use `VCTreeBulkLoader`.
>   - `VectorClusteringTree.createBulkLoader(...)` now accepts and passes `staticStructureFileName` (default `null`).
> - **LSM layer**:
>   - `LSMVCTree.createBulkLoader(...)` accepts `staticStructureFileName` and passes it via `LoadOperation` parameters.
>   - `LSMVCTreeDiskComponent.createBulkLoader(...)` overload to forward optional filename; update references to `VCTreeBulkLoader`.
>   - `LSMVCTreeBulkLoader` now implements `IChainedComponentBulkLoader`, uses `VCTreeBulkLoader`, returns tuple from `add`, stubs `delete`, and reads the filename from op parameters.
> - **Runtime operator**:
>   - `VCTreeSortedDataBulkLoaderOperatorDescriptor`: remove explicit static-structure navigation; initialize bulk loader with `".static_structure_vctree"` so copying happens in constructor.
> - **Tests**:
>   - `VectorTreeTestUtils`: pass `".static_structure_vctree"` when creating bulk loader for static-page import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 788969c43de2cb1502f828ffa2a80ff302598611. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->