### PR TITLE
Topk query before search

### DIFF
--- a/asterixdb/asterix-app/src/main/java/org/apache/asterix/api/common/APIFramework.java
+++ b/asterixdb/asterix-app/src/main/java/org/apache/asterix/api/common/APIFramework.java
@@ -305,6 +305,22 @@ public class APIFramework {
             ICompiler compiler = compilerFactory.createCompiler(plan, metadataProvider, t.getVarCounter());
             if (conf.isOptimize()) {
                 compiler.optimize();
+
+                // ===== DEBUG: Print optimized logical plan =====
+                try {
+                    System.err.println("\n========================================");
+                    System.err.println("OPTIMIZED LOGICAL PLAN:");
+                    System.err.println("========================================");
+                    org.apache.hyracks.algebricks.core.algebra.prettyprint.IPlanPrettyPrinter pPrinter =
+                        org.apache.hyracks.algebricks.core.algebra.prettyprint.PlanPrettyPrinter.createStringPlanPrettyPrinter();
+                    pPrinter.printPlan(plan, false);
+                    System.err.println(pPrinter.toString());
+                    System.err.println("========================================\n");
+                } catch (Exception e) {
+                    System.err.println("Failed to print plan: " + e.getMessage());
+                }
+                // ===== END DEBUG =====
+
                 if (conf.is(SessionConfig.OOB_OPTIMIZED_LOGICAL_PLAN) || isExplainOnly) {
                     if (conf.is(SessionConfig.FORMAT_ONLY_PHYSICAL_OPS)) {
                         // For Optimizer tests. Print physical operators in verbose mode.

--- a/asterixdb/asterix-app/src/main/java/org/apache/asterix/api/common/APIFramework.java
+++ b/asterixdb/asterix-app/src/main/java/org/apache/asterix/api/common/APIFramework.java
@@ -312,7 +312,8 @@ public class APIFramework {
                     System.err.println("OPTIMIZED LOGICAL PLAN:");
                     System.err.println("========================================");
                     org.apache.hyracks.algebricks.core.algebra.prettyprint.IPlanPrettyPrinter pPrinter =
-                        org.apache.hyracks.algebricks.core.algebra.prettyprint.PlanPrettyPrinter.createStringPlanPrettyPrinter();
+                            org.apache.hyracks.algebricks.core.algebra.prettyprint.PlanPrettyPrinter
+                                    .createStringPlanPrettyPrinter();
                     pPrinter.printPlan(plan, false);
                     System.err.println(pPrinter.toString());
                     System.err.println("========================================\n");

--- a/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/declared/MetadataProvider.java
+++ b/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/declared/MetadataProvider.java
@@ -59,6 +59,7 @@ import org.apache.asterix.common.transactions.ITxnIdFactory;
 import org.apache.asterix.common.transactions.TxnId;
 import org.apache.asterix.common.utils.StorageConstants;
 import org.apache.asterix.common.utils.StoragePathUtil;
+import org.apache.asterix.dataflow.data.common.AOrderedListVectorBinaryAccessorFactory;
 import org.apache.asterix.dataflow.data.nontagged.MissingWriterFactory;
 import org.apache.asterix.dataflow.data.nontagged.serde.SerializerDeserializerUtil;
 import org.apache.asterix.external.adapter.factory.ExternalAdapterFactory;
@@ -823,19 +824,21 @@ public class MetadataProvider implements IMetadataProvider<DataSourceId, String>
         // But we only output PK fields, so we skip these 3 fields in the tuple projector
         // TODO: Verify KeyFieldTypeUtil.getNumSecondaryKeys() works correctly for vector indexes,
         //       or keep hardcoded value if tuple format is always <distance, cosine, embedding, pk...>
+        int numSecondaryKeys = 3;  // Hardcoded: distance, cosine, embedding
 
-        //       int numSecondaryKeys = 3;  // Hardcoded: distance, cosine, embedding
-        //       Create VectorSearchOperatorDescriptor
-        //       int[][] partitionsMap = partitioningProperties.getComputeStorageMap();
-        //       VectorSearchOperatorDescriptor vectorSearchOp =
-        //       new VectorSearchOperatorDescriptor(jobSpec,
-        //       outputRecDesc, queryFields, indexDataflowHelperFactory, retainInput, searchCallbackFactory,
-        //       partitionsMap, numPrimaryKeys, numSecondaryKeys);
-        //
-        //       return new Pair<>(vectorSearchOp, partitioningProperties.getConstraints());
+        // Create vector accessor factory for extracting AOrderedList<ADouble> from query tuples
+        // This factory is serializable and passed through the job pipeline
+        // The operator uses it to create accessors that parse AsterixDB's vector format
+        AOrderedListVectorBinaryAccessorFactory vectorAccessorFactory =
+                new AOrderedListVectorBinaryAccessorFactory();
 
-        // TODO: Implement vector search operator creation
-        throw new UnsupportedOperationException("Vector search operator not yet implemented");
+        // Create VectorSearchOperatorDescriptor
+        int[][] partitionsMap = partitioningProperties.getComputeStorageMap();
+        VectorSearchOperatorDescriptor vectorSearchOp = new VectorSearchOperatorDescriptor(jobSpec, outputRecDesc,
+                queryFields, indexDataflowHelperFactory, retainInput, searchCallbackFactory, vectorAccessorFactory,
+                partitionsMap, numPrimaryKeys, numSecondaryKeys);
+
+        return new Pair<>(vectorSearchOp, partitioningProperties.getConstraints());
     }
 
     @Override

--- a/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/declared/MetadataProvider.java
+++ b/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/declared/MetadataProvider.java
@@ -174,6 +174,7 @@ import org.apache.hyracks.storage.am.lsm.btree.dataflow.LSMBTreeBatchPointSearch
 import org.apache.hyracks.storage.am.lsm.invertedindex.dataflow.BinaryTokenizerOperatorDescriptor;
 import org.apache.hyracks.storage.am.lsm.invertedindex.fulltext.IFullTextConfigEvaluatorFactory;
 import org.apache.hyracks.storage.am.lsm.invertedindex.tokenizers.IBinaryTokenizerFactory;
+import org.apache.hyracks.storage.am.lsm.vector.dataflow.VectorSearchOperatorDescriptor;
 import org.apache.hyracks.storage.am.rtree.dataflow.RTreeSearchOperatorDescriptor;
 import org.apache.hyracks.storage.common.IStorageManager;
 import org.apache.hyracks.storage.common.projection.ITupleProjectorFactory;
@@ -824,13 +825,12 @@ public class MetadataProvider implements IMetadataProvider<DataSourceId, String>
         // But we only output PK fields, so we skip these 3 fields in the tuple projector
         // TODO: Verify KeyFieldTypeUtil.getNumSecondaryKeys() works correctly for vector indexes,
         //       or keep hardcoded value if tuple format is always <distance, cosine, embedding, pk...>
-        int numSecondaryKeys = 3;  // Hardcoded: distance, cosine, embedding
+        int numSecondaryKeys = 3; // Hardcoded: distance, cosine, embedding
 
         // Create vector accessor factory for extracting AOrderedList<ADouble> from query tuples
         // This factory is serializable and passed through the job pipeline
         // The operator uses it to create accessors that parse AsterixDB's vector format
-        AOrderedListVectorBinaryAccessorFactory vectorAccessorFactory =
-                new AOrderedListVectorBinaryAccessorFactory();
+        AOrderedListVectorBinaryAccessorFactory vectorAccessorFactory = new AOrderedListVectorBinaryAccessorFactory();
 
         // Create VectorSearchOperatorDescriptor
         int[][] partitionsMap = partitioningProperties.getComputeStorageMap();

--- a/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/entities/Dataset.java
+++ b/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/entities/Dataset.java
@@ -493,9 +493,8 @@ public class Dataset implements IMetadataEntity<Dataset>, IDataset {
                 break;
             case VECTOR:
                 // VECTOR indexes use LSMVCTree (Vector Clustering Tree) for hierarchical IVF
-                resourceFactory = vcTreeResourceFactoryProvider.getResourceFactory(mdProvider, this, index,
-                        recordType, metaType, mergePolicyFactory, mergePolicyProperties, filterTypeTraits,
-                        filterCmpFactories);
+                resourceFactory = vcTreeResourceFactoryProvider.getResourceFactory(mdProvider, this, index, recordType,
+                        metaType, mergePolicyFactory, mergePolicyProperties, filterTypeTraits, filterCmpFactories);
                 break;
             default:
                 throw new CompilationException(ErrorCode.COMPILATION_UNKNOWN_INDEX_TYPE,

--- a/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/entities/Dataset.java
+++ b/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/entities/Dataset.java
@@ -144,6 +144,8 @@ public class Dataset implements IMetadataEntity<Dataset>, IDataset {
             RTreeResourceFactoryProvider.INSTANCE;
     private static final InvertedIndexResourceFactoryProvider invertedIndexResourceFactoryProvider =
             InvertedIndexResourceFactoryProvider.INSTANCE;
+    private static final VCTreeResourceFactoryProvider vcTreeResourceFactoryProvider =
+            VCTreeResourceFactoryProvider.INSTANCE;
     /*
      * Members
      */
@@ -490,8 +492,8 @@ public class Dataset implements IMetadataEntity<Dataset>, IDataset {
                         recordType, metaType, mergePolicyFactory, mergePolicyProperties, null, null);
                 break;
             case VECTOR:
-                // VECTOR indexes use LSMVCTree structure for vector clustering
-                resourceFactory = VCTreeResourceFactoryProvider.INSTANCE.getResourceFactory(mdProvider, this, index,
+                // VECTOR indexes use LSMVCTree (Vector Clustering Tree) for hierarchical IVF
+                resourceFactory = vcTreeResourceFactoryProvider.getResourceFactory(mdProvider, this, index,
                         recordType, metaType, mergePolicyFactory, mergePolicyProperties, filterTypeTraits,
                         filterCmpFactories);
                 break;

--- a/asterixdb/asterix-om/src/main/java/org/apache/asterix/dataflow/data/common/AOrderedListVectorBinaryAccessor.java
+++ b/asterixdb/asterix-om/src/main/java/org/apache/asterix/dataflow/data/common/AOrderedListVectorBinaryAccessor.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.asterix.dataflow.data.common;
+
+import org.apache.asterix.dataflow.data.nontagged.serde.AOrderedListSerializerDeserializer;
+import org.apache.asterix.om.types.ATypeTag;
+import org.apache.asterix.om.types.EnumDeserializer;
+import org.apache.asterix.om.utils.NonTaggedFormatUtil;
+import org.apache.hyracks.api.exceptions.HyracksDataException;
+import org.apache.hyracks.data.std.primitive.DoublePointable;
+import org.apache.hyracks.data.std.primitive.FloatPointable;
+import org.apache.hyracks.data.std.primitive.IntegerPointable;
+import org.apache.hyracks.data.std.primitive.LongPointable;
+import org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessor;
+
+/**
+ * Accessor for extracting vectors from AOrderedList<ADouble> format.
+ * This class handles the AsterixDB-specific serialization format and provides
+ * a clean interface for the Hyracks storage layer.
+ *
+ * Format: [ATypeTag.ORDEREDLIST][ATypeTag.DOUBLE][list metadata][items...]
+ */
+public class AOrderedListVectorBinaryAccessor implements IVectorBinaryAccessor {
+
+    protected byte[] data;
+    protected int start;
+    protected int length;
+    protected int listLength;
+
+    @Override
+    public void reset(byte[] data, int start, int length) throws HyracksDataException {
+        this.data = data;
+        this.start = start;
+        this.length = length;
+        this.listLength = AOrderedListSerializerDeserializer.getNumberOfItems(data, start);
+    }
+
+    @Override
+    public double[] getVector() throws HyracksDataException {
+        if (data == null) {
+            throw new IllegalStateException("Accessor not initialized. Call reset() first.");
+        }
+
+        double[] vector = new double[listLength];
+
+        // Get item type (should be ADouble for vectors)
+        ATypeTag itemType = EnumDeserializer.ATYPETAGDESERIALIZER.deserialize(data[start + 1]);
+
+        for (int i = 0; i < listLength; i++) {
+            int itemOffset = getItemOffset(i);
+            vector[i] = extractNumericValue(itemOffset, itemType);
+        }
+
+        return vector;
+    }
+
+    @Override
+    public int getDimension() throws HyracksDataException {
+        if (data == null) {
+            throw new IllegalStateException("Accessor not initialized. Call reset() first.");
+        }
+        return listLength;
+    }
+
+    /**
+     * Get the byte offset of an item in the list.
+     */
+    protected int getItemOffset(int itemIndex) throws HyracksDataException {
+        return AOrderedListSerializerDeserializer.getItemOffset(data, start, itemIndex);
+    }
+
+    /**
+     * Extract a numeric value from a serialized AsterixDB type.
+     * Handles ADouble, AFloat, AInt32, AInt64.
+     */
+    protected double extractNumericValue(int itemOffset, ATypeTag itemType) throws HyracksDataException {
+        // For homogeneous lists, itemType tells us the type
+        // For heterogeneous lists (itemType == ANY), read type tag from each item
+        ATypeTag actualType = itemType;
+        int valueOffset = itemOffset;
+
+        if (itemType == ATypeTag.ANY) {
+            // Heterogeneous list - read type tag from item
+            actualType = EnumDeserializer.ATYPETAGDESERIALIZER.deserialize(data[itemOffset]);
+            valueOffset = itemOffset + 1;  // Skip type tag
+        }
+
+        switch (actualType) {
+            case DOUBLE:
+                return DoublePointable.getDouble(data, valueOffset);
+            case FLOAT:
+                return FloatPointable.getFloat(data, valueOffset);
+            case INTEGER:
+                return IntegerPointable.getInteger(data, valueOffset);
+            case BIGINT:
+                return LongPointable.getLong(data, valueOffset);
+            default:
+                throw new HyracksDataException("Unsupported numeric type in vector: " + actualType);
+        }
+    }
+}

--- a/asterixdb/asterix-om/src/main/java/org/apache/asterix/dataflow/data/common/AOrderedListVectorBinaryAccessor.java
+++ b/asterixdb/asterix-om/src/main/java/org/apache/asterix/dataflow/data/common/AOrderedListVectorBinaryAccessor.java
@@ -21,7 +21,6 @@ package org.apache.asterix.dataflow.data.common;
 import org.apache.asterix.dataflow.data.nontagged.serde.AOrderedListSerializerDeserializer;
 import org.apache.asterix.om.types.ATypeTag;
 import org.apache.asterix.om.types.EnumDeserializer;
-import org.apache.asterix.om.utils.NonTaggedFormatUtil;
 import org.apache.hyracks.api.exceptions.HyracksDataException;
 import org.apache.hyracks.data.std.primitive.DoublePointable;
 import org.apache.hyracks.data.std.primitive.FloatPointable;
@@ -98,7 +97,7 @@ public class AOrderedListVectorBinaryAccessor implements IVectorBinaryAccessor {
         if (itemType == ATypeTag.ANY) {
             // Heterogeneous list - read type tag from item
             actualType = EnumDeserializer.ATYPETAGDESERIALIZER.deserialize(data[itemOffset]);
-            valueOffset = itemOffset + 1;  // Skip type tag
+            valueOffset = itemOffset + 1; // Skip type tag
         }
 
         switch (actualType) {

--- a/asterixdb/asterix-om/src/main/java/org/apache/asterix/dataflow/data/common/AOrderedListVectorBinaryAccessorFactory.java
+++ b/asterixdb/asterix-om/src/main/java/org/apache/asterix/dataflow/data/common/AOrderedListVectorBinaryAccessorFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.asterix.dataflow.data.common;
+
+import org.apache.hyracks.api.exceptions.HyracksDataException;
+import org.apache.hyracks.api.io.IJsonSerializable;
+import org.apache.hyracks.api.io.IPersistedResourceRegistry;
+import org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessor;
+import org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessorFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Factory for creating AOrderedListVectorBinaryAccessor instances.
+ * This factory is serializable and can be passed from AsterixDB layer to Hyracks layer.
+ */
+public class AOrderedListVectorBinaryAccessorFactory implements IVectorBinaryAccessorFactory {
+
+    private static final long serialVersionUID = 1L;
+
+    public AOrderedListVectorBinaryAccessorFactory() {
+        // No configuration needed for now
+    }
+
+    @Override
+    public IVectorBinaryAccessor createAccessor() {
+        return new AOrderedListVectorBinaryAccessor();
+    }
+
+    @Override
+    public JsonNode toJson(IPersistedResourceRegistry registry) throws HyracksDataException {
+        return registry.getClassIdentifier(getClass(), serialVersionUID);
+    }
+
+    public static IJsonSerializable fromJson(IPersistedResourceRegistry registry, JsonNode json)
+            throws HyracksDataException {
+        return new AOrderedListVectorBinaryAccessorFactory();
+    }
+}

--- a/asterixdb/asterix-om/src/main/java/org/apache/asterix/dataflow/data/common/AOrderedListVectorBinaryAccessorFactory.java
+++ b/asterixdb/asterix-om/src/main/java/org/apache/asterix/dataflow/data/common/AOrderedListVectorBinaryAccessorFactory.java
@@ -25,7 +25,6 @@ import org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessor;
 import org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessorFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Factory for creating AOrderedListVectorBinaryAccessor instances.

--- a/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/evaluators/functions/vector/ANNDistanceDescriptor.java
+++ b/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/evaluators/functions/vector/ANNDistanceDescriptor.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.apache.asterix.runtime.evaluators.functions.vector;
+
+import org.apache.asterix.om.functions.BuiltinFunctions;
+import org.apache.asterix.om.functions.IFunctionDescriptorFactory;
+import org.apache.asterix.runtime.evaluators.base.AbstractScalarFunctionDynamicDescriptor;
+import org.apache.asterix.runtime.functions.FunctionTypeInferers;
+import org.apache.asterix.runtime.utils.DescriptorFactoryUtil;
+import org.apache.hyracks.algebricks.core.algebra.functions.FunctionIdentifier;
+import org.apache.hyracks.algebricks.runtime.base.IScalarEvaluator;
+import org.apache.hyracks.algebricks.runtime.base.IScalarEvaluatorFactory;
+import org.apache.hyracks.api.context.IEvaluatorContext;
+import org.apache.hyracks.api.exceptions.HyracksDataException;
+
+public class ANNDistanceDescriptor extends AbstractScalarFunctionDynamicDescriptor {
+    private static final long serialVersionUID = 1L;
+
+    public final static IFunctionDescriptorFactory FACTORY =
+            DescriptorFactoryUtil.createFactory(ANNDistanceDescriptor::new, FunctionTypeInferers.SET_ARGUMENTS_TYPE);
+
+    @Override
+    public FunctionIdentifier getIdentifier() {
+        return BuiltinFunctions.ANN_DISTANCE;
+    }
+
+    @Override
+    public IScalarEvaluatorFactory createEvaluatorFactory(final IScalarEvaluatorFactory[] args) {
+        return new IScalarEvaluatorFactory() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public IScalarEvaluator createScalarEvaluator(IEvaluatorContext ctx) throws HyracksDataException {
+                return new VectorDistanceArrScalarEvaluator(ctx, args, getIdentifier(), sourceLoc);
+            }
+
+        };
+    }
+
+}

--- a/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/evaluators/functions/vector/ANNDistanceDescriptor.java
+++ b/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/evaluators/functions/vector/ANNDistanceDescriptor.java
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-
 package org.apache.asterix.runtime.evaluators.functions.vector;
 
 import org.apache.asterix.om.functions.BuiltinFunctions;

--- a/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/functions/FunctionCollection.java
+++ b/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/functions/FunctionCollection.java
@@ -642,6 +642,7 @@ import org.apache.asterix.runtime.evaluators.functions.temporal.WeekOfYear2Descr
 import org.apache.asterix.runtime.evaluators.functions.temporal.WeekOfYearDescriptor;
 import org.apache.asterix.runtime.evaluators.functions.temporal.YearMonthDurationGreaterThanComparatorDescriptor;
 import org.apache.asterix.runtime.evaluators.functions.temporal.YearMonthDurationLessThanComparatorDescriptor;
+import org.apache.asterix.runtime.evaluators.functions.vector.ANNDistanceDescriptor;
 import org.apache.asterix.runtime.evaluators.functions.vector.VectorDistanceArrDescriptor;
 import org.apache.asterix.runtime.evaluators.functions.vector.VectorDistanceConstantDescriptor;
 import org.apache.asterix.runtime.runningaggregates.std.DenseRankRunningAggregateDescriptor;
@@ -1329,6 +1330,7 @@ public final class FunctionCollection implements IFunctionCollection {
         // Vector functions
         fc.add(VectorDistanceArrDescriptor.FACTORY);
         fc.add(VectorDistanceConstantDescriptor.FACTORY);
+        fc.add(ANNDistanceDescriptor.FACTORY);
 
         fc.add(KmeanFaissArrDescriptor.FACTORY);
         // Type functions.

--- a/hyracks-fullstack/hyracks/hyracks-api/src/main/java/org/apache/hyracks/api/util/HyracksConstants.java
+++ b/hyracks-fullstack/hyracks/hyracks-api/src/main/java/org/apache/hyracks/api/util/HyracksConstants.java
@@ -32,6 +32,9 @@ public class HyracksConstants {
 
     public static final String ATOMIC_OP_CONTEXT = "ATOMIC_OP_CONTEXT";
 
+    // Vector search query vector (extracted double[] from input tuple)
+    public static final String VECTOR_QUERY = "VECTOR_QUERY";
+
     private HyracksConstants() {
     }
 }

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/api/IVectorBinaryAccessor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/api/IVectorBinaryAccessor.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.hyracks.storage.am.vector.api;
+
+import org.apache.hyracks.api.exceptions.HyracksDataException;
+
+/**
+ * Interface for accessing vector fields in a schema-agnostic way.
+ * Similar to IBinaryComparator for comparisons and IBinaryTokenizer for text processing,
+ * this interface abstracts over different vector serialization formats (e.g., AOrderedList, raw arrays).
+ *
+ * This allows the Hyracks storage layer to work with vectors without knowledge of
+ * AsterixDB-specific type system details.
+ */
+public interface IVectorBinaryAccessor {
+
+    /**
+     * Reset the accessor to point to a new vector field in serialized form.
+     *
+     * @param data Byte array containing the serialized vector
+     * @param start Start offset of the vector field in the byte array
+     * @param length Length of the vector field in bytes
+     * @throws HyracksDataException if the data format is invalid
+     */
+    void reset(byte[] data, int start, int length) throws HyracksDataException;
+
+    /**
+     * Extract and return the vector as a double array.
+     * This performs the actual deserialization from the format-specific representation.
+     *
+     * @return The vector as a double array
+     * @throws HyracksDataException if deserialization fails
+     */
+    double[] getVector() throws HyracksDataException;
+
+    /**
+     * Get the dimensionality of the vector without full extraction.
+     * This can be more efficient than calling getVector().length.
+     *
+     * @return The number of dimensions in the vector
+     * @throws HyracksDataException if the dimension cannot be determined
+     */
+    int getDimension() throws HyracksDataException;
+}

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/api/IVectorBinaryAccessorFactory.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/api/IVectorBinaryAccessorFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.hyracks.storage.am.vector.api;
+
+import java.io.Serializable;
+
+import org.apache.hyracks.api.io.IJsonSerializable;
+
+/**
+ * Factory for creating IVectorBinaryAccessor instances.
+ * Similar to IBinaryTokenizerFactory and IBinaryComparatorFactory,
+ * this factory is serializable and can be passed from AsterixDB layer to Hyracks layer.
+ *
+ * The factory pattern allows AsterixDB-specific implementations to be created
+ * without the Hyracks layer having direct dependencies on AsterixDB modules.
+ */
+public interface IVectorBinaryAccessorFactory extends Serializable, IJsonSerializable {
+
+    /**
+     * Create a new vector binary accessor instance.
+     *
+     * @return A new IVectorBinaryAccessor implementation
+     */
+    IVectorBinaryAccessor createAccessor();
+}

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringAnnCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringAnnCursor.java
@@ -338,7 +338,7 @@ public class VectorClusteringAnnCursor extends EnforcedIndexCursor {
                 int tupleCount = ctx.getMetadataFrame().getTupleCount();
 
                 for (int i = 0; i < tupleCount; i++) {
-                    float maxDistance = ctx.getMetadataFrame().getMaxDistance(i);
+                    double maxDistance = ctx.getMetadataFrame().getMaxDistance(i);
                     long dataPageId = ctx.getMetadataFrame().getDataPagePointer(i);
 
                     // Apply triangle inequality pruning
@@ -366,7 +366,7 @@ public class VectorClusteringAnnCursor extends EnforcedIndexCursor {
     /**
      * Check if a data page should be pruned using triangle inequality.
      */
-    private boolean shouldPrunePage(float maxDistanceInPage, double[] clusterCentroid,
+    private boolean shouldPrunePage(double maxDistanceInPage, double[] clusterCentroid,
             double distanceToClusterCentroid) {
         if (topK.size() < predicate.getK()) {
             return false; // Need more candidates

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringSearchCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringSearchCursor.java
@@ -18,20 +18,14 @@
  */
 package org.apache.hyracks.storage.am.vector.impls;
 
-import org.apache.hyracks.api.dataflow.value.ISerializerDeserializer;
 import org.apache.hyracks.api.exceptions.HyracksDataException;
-import org.apache.hyracks.data.std.primitive.IntegerPointable;
 import org.apache.hyracks.dataflow.common.data.accessors.ITupleReference;
-import org.apache.hyracks.dataflow.common.data.marshalling.FloatArraySerializerDeserializer;
-import org.apache.hyracks.dataflow.common.data.marshalling.IntegerSerializerDeserializer;
-import org.apache.hyracks.dataflow.common.utils.TupleUtils;
 import org.apache.hyracks.storage.am.common.api.ITreeIndexFrameFactory;
 import org.apache.hyracks.storage.am.common.api.ITreeIndexTupleReference;
 import org.apache.hyracks.storage.am.vector.api.IVectorClusteringDataFrame;
 import org.apache.hyracks.storage.am.vector.api.IVectorClusteringInteriorFrame;
 import org.apache.hyracks.storage.am.vector.api.IVectorClusteringLeafFrame;
 import org.apache.hyracks.storage.am.vector.api.IVectorClusteringMetadataFrame;
-import org.apache.hyracks.storage.am.vector.util.VectorUtils;
 import org.apache.hyracks.storage.common.ICursorInitialState;
 import org.apache.hyracks.storage.common.IIndexAccessor;
 import org.apache.hyracks.storage.common.IIndexCursor;
@@ -108,13 +102,8 @@ public class VectorClusteringSearchCursor implements IIndexCursor {
     public void open(ICursorInitialState initialState, ISearchPredicate searchPred) throws HyracksDataException {
         this.isOpen = true;
 
-        // Extract query vector from search predicate if available
-        if (searchPred instanceof VectorPointPredicate) {
-            VectorPointPredicate vectorPred = (VectorPointPredicate) searchPred;
-            this.queryVector = vectorPred.getQueryVector();
-        }
-
-        // If initial state is provided, use its information
+        // Get query vector and other parameters from initial state
+        // The query vector is passed via IIndexAccessParameters from the operator layer
         if (initialState instanceof VectorCursorInitialState) {
             VectorCursorInitialState vectorState = (VectorCursorInitialState) initialState;
             if (vectorState.getQueryVector() != null) {
@@ -219,9 +208,7 @@ public class VectorClusteringSearchCursor implements IIndexCursor {
             int tupleCount = metadataFrame.getTupleCount();
             if (tupleCount > 0) {
                 // Get the first data page from the metadata page
-                ITreeIndexTupleReference tuple = metadataFrame.createTupleReference();
-                tuple.resetByTupleIndex(metadataFrame, 0);
-                return extractDataPageIdFromMetadataTuple(tuple);
+                return metadataFrame.getDataPagePointer(0);
             }
             return -1;
         } finally {
@@ -272,22 +259,6 @@ public class VectorClusteringSearchCursor implements IIndexCursor {
     }
 
     /**
-     * Extract data page ID from a metadata tuple.
-     */
-    private long extractDataPageIdFromMetadataTuple(ITreeIndexTupleReference tuple) {
-        // Metadata tuple format: <max_distance, data_page_id>
-        // Data page ID is in the second field
-
-        // Metadata tuple format: <max_distance, data_page_id>
-        // Data page ID is in the second field (field index 1)
-        byte[] data = tuple.getFieldData(1); // Returns entire buffer
-        int offset = tuple.getFieldStart(1); // Offset to field 1 within buffer
-
-        // FIXED: Use IntegerPointable to extract 4-byte integer (not 8-byte long)
-        return IntegerPointable.getInteger(data, offset);
-    }
-
-    /**
      * Close current data page if open.
      */
     private void closeCurrentPage() throws HyracksDataException {
@@ -316,119 +287,6 @@ public class VectorClusteringSearchCursor implements IIndexCursor {
             throw new IllegalStateException("Data frame factory not set");
         }
         return (IVectorClusteringDataFrame) dataFrameFactory.createFrame();
-    }
-
-    /**
-     * Find the closest cluster by traversing the tree from root to leaf.
-     * This integrates the centroid finding logic into the cursor.
-     */
-    private ClusterSearchResult findClosestClusterFromRoot(float[] queryVector) throws HyracksDataException {
-        // Start from root page
-        int currentPageId = rootPageId;
-        double bestDistance = Double.MAX_VALUE;
-        ClusterSearchResult bestResult = null;
-        int loopCounter = 0;
-
-        // Traverse from root to leaf
-        while (true) {
-            loopCounter++;
-            if (loopCounter > 10) { // Safety check to prevent infinite loops
-                throw HyracksDataException
-                        .create(new IllegalStateException("Infinite loop detected in tree traversal"));
-            }
-
-            ICachedPage page = bufferCache.pin(BufferedFileHandle.getDiskPageId(fileId, currentPageId));
-
-            try {
-                page.acquireReadLatch();
-
-                // Check if this is a leaf page
-                IVectorClusteringLeafFrame leafFrame = createLeafFrame();
-                leafFrame.setPage(page);
-                boolean isLeaf = leafFrame.isLeaf();
-
-                if (isLeaf) {
-                    // Leaf level - find closest centroid
-                    int tupleCount = leafFrame.getTupleCount();
-                    int bestClusterIndex = -1;
-                    double leafBestDistance = Double.MAX_VALUE;
-
-                    for (int i = 0; i < tupleCount; i++) {
-                        // Get centroid from leaf frame tuple
-                        ITreeIndexTupleReference frameTuple = leafFrame.createTupleReference();
-                        frameTuple.resetByTupleIndex(leafFrame, i);
-                        double[] centroid = extractCentroidFromLeafTuple(frameTuple);
-
-                        // Check vector dimensionality
-                        if (centroid.length != queryVector.length) {
-                            continue;
-                        }
-
-                        double distance = VectorUtils.calculateEuclideanDistance(queryVector, centroid);
-
-                        if (distance < leafBestDistance) {
-                            leafBestDistance = distance;
-                            bestClusterIndex = i;
-                        }
-                    }
-
-                    if (bestClusterIndex >= 0) {
-                        ITreeIndexTupleReference frameTuple = leafFrame.createTupleReference();
-                        frameTuple.resetByTupleIndex(leafFrame, bestClusterIndex);
-                        double[] bestCentroid = extractCentroidFromLeafTuple(frameTuple);
-                        bestResult = new ClusterSearchResult(currentPageId, bestClusterIndex, bestCentroid,
-                                leafBestDistance, 0);
-                    }
-                    break; // Found leaf level result
-
-                } else {
-                    // Interior level - find closest centroid and descend
-                    IVectorClusteringInteriorFrame interiorFrame = createInteriorFrame();
-                    interiorFrame.setPage(page);
-                    int tupleCount = interiorFrame.getTupleCount();
-                    int bestChildIndex = -1;
-                    bestDistance = Double.MAX_VALUE;
-
-                    for (int i = 0; i < tupleCount; i++) {
-                        // Get centroid from interior frame tuple
-                        ITreeIndexTupleReference frameTuple = interiorFrame.createTupleReference();
-                        frameTuple.resetByTupleIndex(interiorFrame, i);
-                        double[] centroid = extractCentroidFromInteriorTuple(frameTuple);
-
-                        // Check vector dimensionality
-                        if (centroid.length != queryVector.length) {
-                            continue;
-                        }
-
-                        double distance = VectorUtils.calculateEuclideanDistance(queryVector, centroid);
-
-                        if (distance < bestDistance) {
-                            bestDistance = distance;
-                            bestChildIndex = i;
-                        }
-                    }
-
-                    if (bestChildIndex >= 0) {
-                        // Get child page ID for best centroid
-                        int nextPageId = interiorFrame.getChildPageId(bestChildIndex);
-                        currentPageId = nextPageId;
-                    } else {
-                        throw HyracksDataException
-                                .create(new IllegalStateException("No valid centroid found in interior page"));
-                    }
-                }
-
-            } finally {
-                page.releaseReadLatch();
-                bufferCache.unpin(page);
-            }
-        }
-
-        if (bestResult == null) {
-            throw HyracksDataException.create(new IllegalStateException("No closest cluster found"));
-        }
-
-        return bestResult;
     }
 
     /**
@@ -462,70 +320,6 @@ public class VectorClusteringSearchCursor implements IIndexCursor {
             throw new IllegalStateException("Leaf frame factory not set");
         }
         return (IVectorClusteringLeafFrame) leafFrameFactory.createFrame();
-    }
-
-    /**
-     * Extract centroid from a leaf frame tuple (format: <cid, centroid, metadata_ptr>).
-     */
-    private double[] extractCentroidFromLeafTuple(ITreeIndexTupleReference tuple) {
-        // Centroid is the second field in leaf frame tuples
-        try {
-            // Create field serializers array - specify only the centroid field we need
-            ISerializerDeserializer[] fieldSerdes = new ISerializerDeserializer[3];
-            fieldSerdes[0] = IntegerSerializerDeserializer.INSTANCE; // Field 0: cid
-            fieldSerdes[1] = FloatArraySerializerDeserializer.INSTANCE; // Field 1: centroid
-            fieldSerdes[2] = IntegerSerializerDeserializer.INSTANCE; // Field 2: metadata_pointer
-
-            // Deserialize the tuple using the proper TupleUtils method
-            Object[] fieldValues = TupleUtils.deserializeTuple(tuple, fieldSerdes);
-
-            // Extract the centroid from the deserialized fields
-            float[] floatCentroid = (float[]) fieldValues[1];
-
-            // Convert from float[] to double[]
-            double[] doubleCentroid = new double[floatCentroid.length];
-            for (int i = 0; i < floatCentroid.length; i++) {
-                doubleCentroid[i] = floatCentroid[i];
-            }
-
-            return doubleCentroid;
-
-        } catch (Exception e) {
-            throw new RuntimeException(
-                    "Failed to extract centroid from interior tuple using TupleUtils.deserializeTuple()", e);
-        }
-    }
-
-    /**
-     * Extract centroid from an interior frame tuple (format: <cid, centroid, child_ptr>).
-     */
-    private double[] extractCentroidFromInteriorTuple(ITreeIndexTupleReference tuple) {
-        // Centroid is the second field in interior frame tuples
-        try {
-            // Create field serializers array - specify only the centroid field we need
-            ISerializerDeserializer[] fieldSerdes = new ISerializerDeserializer[3];
-            fieldSerdes[0] = IntegerSerializerDeserializer.INSTANCE; // Field 0: cid
-            fieldSerdes[1] = FloatArraySerializerDeserializer.INSTANCE; // Field 1: centroid
-            fieldSerdes[2] = IntegerSerializerDeserializer.INSTANCE; // Field 2: metadata_pointer
-
-            // Deserialize the tuple using the proper TupleUtils method
-            Object[] fieldValues = TupleUtils.deserializeTuple(tuple, fieldSerdes);
-
-            // Extract the centroid from the deserialized fields
-            float[] floatCentroid = (float[]) fieldValues[1];
-
-            // Convert from float[] to double[]
-            double[] doubleCentroid = new double[floatCentroid.length];
-            for (int i = 0; i < floatCentroid.length; i++) {
-                doubleCentroid[i] = floatCentroid[i];
-            }
-
-            return doubleCentroid;
-
-        } catch (Exception e) {
-            throw new RuntimeException(
-                    "Failed to extract centroid from interior tuple using TupleUtils.deserializeTuple()", e);
-        }
     }
 
     @Override

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTree.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTree.java
@@ -29,6 +29,7 @@ import org.apache.hyracks.api.dataflow.value.ISerializerDeserializer;
 import org.apache.hyracks.api.exceptions.ErrorCode;
 import org.apache.hyracks.api.exceptions.HyracksDataException;
 import org.apache.hyracks.api.io.FileReference;
+import org.apache.hyracks.api.util.HyracksConstants;
 import org.apache.hyracks.dataflow.common.data.accessors.ITupleReference;
 import org.apache.hyracks.dataflow.common.data.marshalling.DoubleArraySerializerDeserializer;
 import org.apache.hyracks.dataflow.common.data.marshalling.DoubleSerializerDeserializer;
@@ -44,6 +45,8 @@ import org.apache.hyracks.storage.am.common.impls.AbstractTreeIndex;
 import org.apache.hyracks.storage.am.common.impls.TreeIndexDiskOrderScanCursor;
 import org.apache.hyracks.storage.am.common.ophelpers.IndexOperation;
 import org.apache.hyracks.storage.am.common.tuples.SimpleTupleReference;
+import org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessor;
+import org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessorFactory;
 import org.apache.hyracks.storage.am.vector.api.IVectorClusteringDataFrame;
 import org.apache.hyracks.storage.am.vector.api.IVectorClusteringMetadataFrame;
 import org.apache.hyracks.storage.am.vector.frames.VectorClusteringDataFrame;
@@ -1396,10 +1399,12 @@ public class VectorClusteringTree extends AbstractTreeIndex {
 
         private VectorClusteringTree tree;
         private VectorClusteringOpContext ctx;
+        private IIndexAccessParameters iap;
         private boolean destroyed = false;
 
         public VectorClusteringTreeAccessor(VectorClusteringTree tree, IIndexAccessParameters iap) {
             this.tree = tree;
+            this.iap = iap;
             this.ctx = new VectorClusteringOpContext(this, tree.interiorFrameFactory, tree.leafFrameFactory,
                     tree.metadataFrameFactory, tree.dataFrameFactory, tree.freePageManager, tree.cmpFactories,
                     tree.vectorDimensions, iap.getModificationCallback(), iap.getSearchOperationCallback());
@@ -1407,6 +1412,7 @@ public class VectorClusteringTree extends AbstractTreeIndex {
 
         public void reset(VectorClusteringTree vctree, IIndexAccessParameters iap) {
             this.tree = vctree;
+            this.iap = iap;
             ctx.setCallbacks(iap.getModificationCallback(), iap.getSearchOperationCallback());
             ctx.reset();
         }
@@ -1467,9 +1473,38 @@ public class VectorClusteringTree extends AbstractTreeIndex {
             vectorCursor.setFrameFactories(tree.interiorFrameFactory, tree.leafFrameFactory, tree.metadataFrameFactory,
                     tree.dataFrameFactory);
 
-            // Create a simple initial state (the cursor will find the centroid itself)
+            // Extract query vector from predicate using the accessor factory
+            // The predicate holds the tuple reference (updated per-tuple in resetSearchPredicate)
+            double[] queryVector = null;
+            if (searchPred instanceof VectorPointPredicate) {
+                VectorPointPredicate vectorPred = (VectorPointPredicate) searchPred;
+                ITupleReference queryTuple = vectorPred.getQueryTuple();
+                int queryFieldIndex = vectorPred.getQueryFieldIndex();
+
+                if (queryTuple != null) {
+                    // Get accessor factory from parameters (stored during index accessor creation)
+                    IVectorBinaryAccessorFactory factory =
+                            (IVectorBinaryAccessorFactory) iap.getParameters().get(HyracksConstants.VECTOR_QUERY);
+
+                    if (factory != null) {
+                        // Create accessor and extract vector from tuple
+                        IVectorBinaryAccessor accessor = factory.createAccessor();
+                        accessor.reset(
+                            queryTuple.getFieldData(queryFieldIndex),
+                            queryTuple.getFieldStart(queryFieldIndex),
+                            queryTuple.getFieldLength(queryFieldIndex)
+                        );
+                        queryVector = accessor.getVector();
+                    }
+                }
+            }
+
+            // Create initial state with query vector
             VectorCursorInitialState initialState = new VectorCursorInitialState(ctx.getAccessor());
             initialState.setRootPageId(tree.rootPage);
+            if (queryVector != null) {
+                initialState.setQueryVector(queryVector);
+            }
 
             // Open the cursor - it will perform centroid finding and position on data pages
             vectorCursor.open(initialState, searchPred);

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTree.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTree.java
@@ -1489,11 +1489,8 @@ public class VectorClusteringTree extends AbstractTreeIndex {
                     if (factory != null) {
                         // Create accessor and extract vector from tuple
                         IVectorBinaryAccessor accessor = factory.createAccessor();
-                        accessor.reset(
-                            queryTuple.getFieldData(queryFieldIndex),
-                            queryTuple.getFieldStart(queryFieldIndex),
-                            queryTuple.getFieldLength(queryFieldIndex)
-                        );
+                        accessor.reset(queryTuple.getFieldData(queryFieldIndex),
+                                queryTuple.getFieldStart(queryFieldIndex), queryTuple.getFieldLength(queryFieldIndex));
                         queryVector = accessor.getVector();
                     }
                 }

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTree.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTree.java
@@ -87,7 +87,7 @@ public class VectorClusteringTree extends AbstractTreeIndex {
 
     private VectorClusteringTreeStaticInitializer staticInitializer;
 
-    private boolean isStaticStructureInitialized = false;
+    private boolean isStaticStructureInitialized = true;
 
     public VectorClusteringTree(IBufferCache bufferCache, IPageManager freePageManager,
             ITreeIndexFrameFactory interiorFrameFactory, ITreeIndexFrameFactory leafFrameFactory,

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorPointPredicate.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorPointPredicate.java
@@ -24,39 +24,71 @@ import org.apache.hyracks.storage.common.MultiComparator;
 
 /**
  * Search predicate for vector point queries.
- * Used for finding the closest cluster to a query vector.
+ * Holds a reference to the query tuple for per-tuple vector searches.
+ *
+ * Following the Reference Pattern (like RTree): The predicate holds an ITupleReference
+ * that is updated per-tuple by resetSearchPredicate(). The storage layer extracts
+ * the query vector when needed during search.
  */
 public class VectorPointPredicate implements ISearchPredicate {
     private static final long serialVersionUID = 1L;
 
-    private final double[] queryVector;
+    private ITupleReference queryTuple;
+    private int queryFieldIndex;
 
-    public VectorPointPredicate(double[] queryVector) {
-        this.queryVector = queryVector;
+    public VectorPointPredicate() {
+        // Empty constructor for initialization
     }
 
-    public double[] getQueryVector() {
-        return queryVector;
+    public VectorPointPredicate(double[] queryVector) {
+        // Constructor kept for compatibility with tests
+        // In runtime, query data comes via setQueryTuple()
+    }
+
+    /**
+     * Set the query tuple containing the vector field.
+     * Called by resetSearchPredicate() for each input tuple.
+     */
+    public void setQueryTuple(ITupleReference queryTuple) {
+        this.queryTuple = queryTuple;
+    }
+
+    /**
+     * Set the field index of the vector in the query tuple.
+     */
+    public void setQueryFieldIndex(int queryFieldIndex) {
+        this.queryFieldIndex = queryFieldIndex;
+    }
+
+    /**
+     * Get the query tuple reference.
+     */
+    public ITupleReference getQueryTuple() {
+        return queryTuple;
+    }
+
+    /**
+     * Get the query field index.
+     */
+    public int getQueryFieldIndex() {
+        return queryFieldIndex;
     }
 
     @Override
     public MultiComparator getLowKeyComparator() {
         // Vector clustering tree doesn't use traditional key comparisons
-        // This method is not applicable for vector searches
         return null;
     }
 
     @Override
     public MultiComparator getHighKeyComparator() {
         // Vector clustering tree doesn't use traditional key comparisons
-        // This method is not applicable for vector searches
         return null;
     }
 
     @Override
     public ITupleReference getLowKey() {
         // Vector clustering tree doesn't use traditional key searches
-        // This method is not applicable for vector searches
         return null;
     }
 
@@ -74,11 +106,6 @@ public class VectorPointPredicate implements ISearchPredicate {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("VectorPointPredicate[");
-        if (queryVector != null) {
-            sb.append("dimensions=").append(queryVector.length);
-        }
-        sb.append("]");
-        return sb.toString();
+        return "VectorPointPredicate[queryTuple=" + (queryTuple != null ? "set" : "null") + "]";
     }
 }

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/VectorSearchOperatorDescriptor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/VectorSearchOperatorDescriptor.java
@@ -69,7 +69,7 @@ public class VectorSearchOperatorDescriptor extends AbstractSingleActivityOperat
             int[] queryFields, IIndexDataflowHelperFactory indexHelperFactory, boolean retainInput,
             ISearchOperationCallbackFactory searchCallbackFactory, IVectorBinaryAccessorFactory vectorAccessorFactory,
             int[][] partitionsMap, int numPrimaryKeys, int numSecondaryKeys) {
-        super(spec, 1, 1);  // 1 input, 1 output
+        super(spec, 1, 1); // 1 input, 1 output
         this.queryFields = queryFields;
         this.indexHelperFactory = indexHelperFactory;
         this.retainInput = retainInput;

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/VectorSearchOperatorDescriptor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/VectorSearchOperatorDescriptor.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.hyracks.storage.am.lsm.vector.dataflow;
+
+import org.apache.hyracks.api.context.IHyracksTaskContext;
+import org.apache.hyracks.api.dataflow.IOperatorNodePushable;
+import org.apache.hyracks.api.dataflow.value.IRecordDescriptorProvider;
+import org.apache.hyracks.api.dataflow.value.RecordDescriptor;
+import org.apache.hyracks.api.exceptions.HyracksDataException;
+import org.apache.hyracks.api.job.IOperatorDescriptorRegistry;
+import org.apache.hyracks.dataflow.std.base.AbstractSingleActivityOperatorDescriptor;
+import org.apache.hyracks.storage.am.common.api.ISearchOperationCallbackFactory;
+import org.apache.hyracks.storage.am.common.dataflow.IIndexDataflowHelperFactory;
+import org.apache.hyracks.storage.am.lsm.vector.impls.PKOnlyTupleProjectorFactory;
+import org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessorFactory;
+import org.apache.hyracks.storage.common.projection.ITupleProjectorFactory;
+
+/**
+ * Operator descriptor for vector index search (ANN search).
+ * This creates the runtime operator (VectorSearchOperatorNodePushable) that performs
+ * the actual search on each node controller.
+ */
+public class VectorSearchOperatorDescriptor extends AbstractSingleActivityOperatorDescriptor {
+
+    private static final long serialVersionUID = 1L;
+
+    // Field indexes in input tuple: [query_vector_field, k_field, metric_field]
+    protected final int[] queryFields;
+
+    // Factory to open LSMVCTree index
+    protected final IIndexDataflowHelperFactory indexHelperFactory;
+
+    // Whether to retain input tuples in output
+    protected final boolean retainInput;
+
+    // Transaction callback factory
+    protected final ISearchOperationCallbackFactory searchCallbackFactory;
+
+    // Partition mapping (compute nodes to storage nodes)
+    protected final int[][] partitionsMap;
+
+    // Number of primary and secondary keys for tuple projection
+    protected final int numPrimaryKeys;
+    protected final int numSecondaryKeys;
+
+    // Tuple projector factory (extracts only PKs from index results)
+    protected final ITupleProjectorFactory tupleProjectorFactory;
+
+    // Factory for creating vector binary accessors (for extracting AOrderedList<ADouble>)
+    protected final IVectorBinaryAccessorFactory vectorAccessorFactory;
+
+    public VectorSearchOperatorDescriptor(IOperatorDescriptorRegistry spec, RecordDescriptor outRecDesc,
+            int[] queryFields, IIndexDataflowHelperFactory indexHelperFactory, boolean retainInput,
+            ISearchOperationCallbackFactory searchCallbackFactory, IVectorBinaryAccessorFactory vectorAccessorFactory,
+            int[][] partitionsMap, int numPrimaryKeys, int numSecondaryKeys) {
+        super(spec, 1, 1);  // 1 input, 1 output
+        this.queryFields = queryFields;
+        this.indexHelperFactory = indexHelperFactory;
+        this.retainInput = retainInput;
+        this.searchCallbackFactory = searchCallbackFactory;
+        this.vectorAccessorFactory = vectorAccessorFactory;
+        this.partitionsMap = partitionsMap;
+        this.numPrimaryKeys = numPrimaryKeys;
+        this.numSecondaryKeys = numSecondaryKeys;
+        this.outRecDescs[0] = outRecDesc;
+
+        // Create tuple projector factory that extracts only PK fields
+        // This avoids writing large embedding vectors (4KB-16KB) to output frames
+        this.tupleProjectorFactory = new PKOnlyTupleProjectorFactory(numSecondaryKeys, numPrimaryKeys);
+    }
+
+    @Override
+    public IOperatorNodePushable createPushRuntime(final IHyracksTaskContext ctx,
+            IRecordDescriptorProvider recordDescProvider, int partition, int nPartitions) throws HyracksDataException {
+        return new VectorSearchOperatorNodePushable(ctx, partition,
+                recordDescProvider.getInputRecordDescriptor(getActivityId(), 0), queryFields, indexHelperFactory,
+                retainInput, searchCallbackFactory, tupleProjectorFactory, vectorAccessorFactory, partitionsMap);
+    }
+}

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/VectorSearchOperatorNodePushable.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/VectorSearchOperatorNodePushable.java
@@ -72,14 +72,11 @@ public class VectorSearchOperatorNodePushable extends IndexSearchOperatorNodePus
         // Note: No tuple filter for now (pass null)
         // Note: No output limit for now (pass -1)
         // Note: No search callback result needed (pass false)
-        super(ctx, inputRecDesc, partition,
-                null, // minFilterFieldIndexes
+        super(ctx, inputRecDesc, partition, null, // minFilterFieldIndexes
                 null, // maxFilterFieldIndexes
-                indexHelperFactory, retainInput,
-                false, // retainMissing
+                indexHelperFactory, retainInput, false, // retainMissing
                 null, // nonMatchWriterFactory
-                searchCallbackFactory,
-                false, // appendIndexFilter
+                searchCallbackFactory, false, // appendIndexFilter
                 null, // nonFilterWriterFactory
                 null, // tupleFilterFactory
                 -1, // outputLimit
@@ -117,7 +114,7 @@ public class VectorSearchOperatorNodePushable extends IndexSearchOperatorNodePus
             // Following RTree pattern: predicate holds reference, updated per-tuple
             VectorPointPredicate vectorPred = (VectorPointPredicate) searchPred;
             vectorPred.setQueryTuple(queryParamsTuple);
-            vectorPred.setQueryFieldIndex(0);  // Field 0 is the vector field
+            vectorPred.setQueryFieldIndex(0); // Field 0 is the vector field
         }
     }
 

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/VectorSearchOperatorNodePushable.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/VectorSearchOperatorNodePushable.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.hyracks.storage.am.lsm.vector.dataflow;
+
+import org.apache.hyracks.api.context.IHyracksTaskContext;
+import org.apache.hyracks.api.dataflow.value.RecordDescriptor;
+import org.apache.hyracks.api.exceptions.HyracksDataException;
+import org.apache.hyracks.api.util.HyracksConstants;
+import org.apache.hyracks.dataflow.common.data.accessors.PermutingFrameTupleReference;
+import org.apache.hyracks.storage.am.common.api.ISearchOperationCallbackFactory;
+import org.apache.hyracks.storage.am.common.dataflow.IIndexDataflowHelperFactory;
+import org.apache.hyracks.storage.am.common.dataflow.IndexSearchOperatorNodePushable;
+import org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessorFactory;
+import org.apache.hyracks.storage.am.vector.impls.VectorPointPredicate;
+import org.apache.hyracks.storage.common.IIndex;
+import org.apache.hyracks.storage.common.IIndexAccessParameters;
+import org.apache.hyracks.storage.common.ISearchPredicate;
+import org.apache.hyracks.storage.common.projection.ITupleProjectorFactory;
+
+/**
+ * Runtime operator for vector index search (ANN search).
+ * Extends IndexSearchOperatorNodePushable which handles the heavy lifting:
+ * - Opening/closing indexes
+ * - Frame/tuple iteration
+ * - Output buffering
+ * - Transaction callbacks
+ *
+ * This class implements the schema-agnostic pattern using IVectorBinaryAccessor
+ * to abstract over different vector serialization formats (e.g., AOrderedList).
+ *
+ * This class only needs to implement:
+ * 1. createSearchPredicate() - Create VectorPointPredicate with accessor
+ * 2. resetSearchPredicate() - Set query tuple reference (no deserialization!)
+ * 3. getFieldCount() - Return number of output fields
+ * 4. addAdditionalIndexAccessorParams() - Add vector-specific params (if any)
+ */
+public class VectorSearchOperatorNodePushable extends IndexSearchOperatorNodePushable {
+
+    // Field indexes in input tuple: [query_vector_field, k_field, metric_field]
+    protected final int[] queryFields;
+
+    // Factory for creating vector accessors (passed from AsterixDB layer)
+    protected final IVectorBinaryAccessorFactory vectorAccessorFactory;
+
+    // Tuple reference for extracting query parameters
+    protected PermutingFrameTupleReference queryParamsTuple;
+
+    public VectorSearchOperatorNodePushable(IHyracksTaskContext ctx, int partition, RecordDescriptor inputRecDesc,
+            int[] queryFields, IIndexDataflowHelperFactory indexHelperFactory, boolean retainInput,
+            ISearchOperationCallbackFactory searchCallbackFactory, ITupleProjectorFactory projectorFactory,
+            IVectorBinaryAccessorFactory vectorAccessorFactory, int[][] partitionsMap) throws HyracksDataException {
+        // Call parent constructor
+        // Note: Vector search doesn't need min/max filter fields (pass null)
+        // Note: Vector search doesn't need missing writer (pass null for retainMissing)
+        // Note: No index filter for now (pass false for appendIndexFilter)
+        // Note: No tuple filter for now (pass null)
+        // Note: No output limit for now (pass -1)
+        // Note: No search callback result needed (pass false)
+        super(ctx, inputRecDesc, partition,
+                null, // minFilterFieldIndexes
+                null, // maxFilterFieldIndexes
+                indexHelperFactory, retainInput,
+                false, // retainMissing
+                null, // nonMatchWriterFactory
+                searchCallbackFactory,
+                false, // appendIndexFilter
+                null, // nonFilterWriterFactory
+                null, // tupleFilterFactory
+                -1, // outputLimit
+                false, // appendOpCallbackProceedResult
+                null, // searchCallbackProceedResultFalseValue
+                null, // searchCallbackProceedResultTrueValue
+                projectorFactory, // ← PKOnlyTupleProjectorFactory (extracts only PK fields)
+                null, // tuplePartitionerFactory
+                partitionsMap);
+
+        this.queryFields = queryFields;
+        this.vectorAccessorFactory = vectorAccessorFactory;
+
+        // Setup permuting tuple reference to extract query parameters
+        if (queryFields != null && queryFields.length > 0) {
+            queryParamsTuple = new PermutingFrameTupleReference();
+            queryParamsTuple.setFieldPermutation(queryFields);
+        }
+    }
+
+    @Override
+    protected ISearchPredicate createSearchPredicate(IIndex index) {
+        // Create simple marker predicate
+        // The actual query vector is passed via IIndexAccessParameters in addAdditionalIndexAccessorParams()
+        return new VectorPointPredicate();
+    }
+
+    @Override
+    protected void resetSearchPredicate(int tupleIndex) {
+        // Update queryParamsTuple to point to current input tuple
+        if (queryParamsTuple != null) {
+            queryParamsTuple.reset(accessor, tupleIndex);
+
+            // Update predicate with current tuple reference
+            // Following RTree pattern: predicate holds reference, updated per-tuple
+            VectorPointPredicate vectorPred = (VectorPointPredicate) searchPred;
+            vectorPred.setQueryTuple(queryParamsTuple);
+            vectorPred.setQueryFieldIndex(0);  // Field 0 is the vector field
+        }
+    }
+
+    @Override
+    protected int getFieldCount(IIndex index) {
+        // For vector index, we only output primary keys (no secondary keys/embeddings)
+        // The number of fields is determined by the dataset's primary key count
+        //
+        // TODO: Get actual PK count from index metadata
+        // For now, assume single PK field (common case)
+        return 1;
+
+        // When implementing properly:
+        // LSMVCTree lsmvcTree = (LSMVCTree) index;
+        // return lsmvcTree.getNumPrimaryKeys();  // Or similar method
+    }
+
+    @Override
+    protected void addAdditionalIndexAccessorParams(IIndexAccessParameters iap) {
+        // Store the vector accessor factory in parameters
+        // The VCTree accessor will extract the query vector from the predicate during search()
+        // This maintains layer separation: extraction happens in storage layer using the factory
+        iap.getParameters().put(HyracksConstants.VECTOR_QUERY, vectorAccessorFactory);
+    }
+}

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTree.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTree.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.hyracks.api.dataflow.value.IBinaryComparatorFactory;
-import org.apache.hyracks.api.dataflow.value.ISerializerDeserializer;
-import org.apache.hyracks.api.exceptions.ErrorCode;
 import org.apache.hyracks.api.exceptions.ErrorCode;
 import org.apache.hyracks.api.exceptions.HyracksDataException;
 import org.apache.hyracks.api.io.FileReference;
@@ -541,8 +539,8 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
         if (ssFileRefeference == null) {
             return;
         }
-        ILSMDiskComponent ssComponent = createStaticStructure(componentFactory, ssFileRefeference.getStaticStructureFileReference(),
-                null, null, false);
+        ILSMDiskComponent ssComponent = createStaticStructure(componentFactory,
+                ssFileRefeference.getStaticStructureFileReference(), null, null, false);
         setStaticStructure((LSMVCTreeDiskComponent) ssComponent);
     }
 

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTree.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTree.java
@@ -428,7 +428,7 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
     public LSMVCTreeOpContext createOpContext(IIndexAccessParameters iap) {
         return new LSMVCTreeOpContext(this, getTreeFields(), getFilterFields(), getFilterCmpFactories(),
                 (IExtendedModificationOperationCallback) iap.getModificationCallback(),
-                iap.getSearchOperationCallback(), tracer);
+                iap.getSearchOperationCallback(), tracer, iap);
     }
 
     @Override

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTree.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTree.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.hyracks.api.dataflow.value.IBinaryComparatorFactory;
+import org.apache.hyracks.api.dataflow.value.ISerializerDeserializer;
+import org.apache.hyracks.api.exceptions.ErrorCode;
 import org.apache.hyracks.api.exceptions.ErrorCode;
 import org.apache.hyracks.api.exceptions.HyracksDataException;
 import org.apache.hyracks.api.io.FileReference;
@@ -73,6 +75,8 @@ import org.apache.hyracks.storage.common.MultiComparator;
 import org.apache.hyracks.storage.common.buffercache.IBufferCache;
 import org.apache.hyracks.storage.common.buffercache.ICachedPage;
 import org.apache.hyracks.util.trace.ITracer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * LSM Vector Clustering Tree implementation for hierarchical vector clustering with LSM storage.
@@ -81,6 +85,7 @@ import org.apache.hyracks.util.trace.ITracer;
  * 
  */
 public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
+    private static final Logger LOGGER = LogManager.getLogger();
 
     private static final ICursorFactory cursorFactory = LSMVCTreeSearchCursor::new;
     private static final ICursorFactory annCursorFactory = LSMVCTreeAnnCursor::new;
@@ -442,6 +447,14 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
         return mutableComponent.getIndex().getInteriorFrameFactory();
     }
 
+    public ITreeIndexFrameFactory getMetadataFrameFactory() {
+        return metadataFrameFactory;
+    }
+
+    public ITreeIndexFrameFactory getDataFrameFactory() {
+        return dataFrameFactory;
+    }
+
     @Override
     public int getFieldCount() {
         LSMVCTreeMemoryComponent mutableComponent =
@@ -528,8 +541,8 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
         if (ssFileRefeference == null) {
             return;
         }
-        ILSMDiskComponent ssComponent = createStaticStructure(componentFactory,
-                ssFileRefeference.getStaticStructureFileReference(), null, null, false);
+        ILSMDiskComponent ssComponent = createStaticStructure(componentFactory, ssFileRefeference.getStaticStructureFileReference(),
+                null, null, false);
         setStaticStructure((LSMVCTreeDiskComponent) ssComponent);
     }
 

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeOpContext.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeOpContext.java
@@ -46,7 +46,9 @@ public class LSMVCTreeOpContext extends AbstractLSMIndexOperationContext {
             IBinaryComparatorFactory[] filterCmpFactories, IExtendedModificationOperationCallback modificationCallback,
             ISearchOperationCallback searchCallback, ITracer tracer) {
         super(lsmTree, treeFields, filterFields, filterCmpFactories, searchCallback, modificationCallback, tracer);
-        this.searchInitialState = null; // Will be created when needed
+        this.searchInitialState = new LSMVCTreeCursorInitialState(lsmTree.getInteriorFrameFactory(),
+                lsmTree.getLeafFrameFactory(), lsmTree.getMetadataFrameFactory(), lsmTree.getDataFrameFactory(), null,
+                lsmTree.getHarness(), null, searchCallback, componentHolder);
     }
 
     @Override

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeOpContext.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeOpContext.java
@@ -23,16 +23,16 @@ import org.apache.hyracks.api.dataflow.value.IBinaryComparatorFactory;
 import org.apache.hyracks.api.exceptions.HyracksDataException;
 import org.apache.hyracks.storage.am.common.api.IExtendedModificationOperationCallback;
 import org.apache.hyracks.storage.am.common.api.ITreeIndexAccessor;
-import org.apache.hyracks.storage.am.common.impls.IndexAccessParameters;
 import org.apache.hyracks.storage.am.common.ophelpers.IndexOperation;
 import org.apache.hyracks.storage.am.lsm.common.impls.AbstractLSMIndexOperationContext;
+import org.apache.hyracks.storage.common.IIndexAccessParameters;
 import org.apache.hyracks.storage.common.ISearchOperationCallback;
 import org.apache.hyracks.storage.common.ISearchPredicate;
 import org.apache.hyracks.util.trace.ITracer;
 
 /**
  * Operation context for LSM Vector Clustering Tree operations.
- * 
+ *
  * This context manages the state and resources needed for vector clustering
  * operations across multiple LSM components.
  */
@@ -41,11 +41,13 @@ public class LSMVCTreeOpContext extends AbstractLSMIndexOperationContext {
     private LSMVCTreeCursorInitialState searchInitialState;
     private ISearchPredicate searchPredicate;
     private int currentMutableComponentId = 0;
+    private final IIndexAccessParameters iap;
 
     public LSMVCTreeOpContext(LSMVCTree lsmTree, int[] treeFields, int[] filterFields,
             IBinaryComparatorFactory[] filterCmpFactories, IExtendedModificationOperationCallback modificationCallback,
-            ISearchOperationCallback searchCallback, ITracer tracer) {
+            ISearchOperationCallback searchCallback, ITracer tracer, IIndexAccessParameters iap) {
         super(lsmTree, treeFields, filterFields, filterCmpFactories, searchCallback, modificationCallback, tracer);
+        this.iap = iap;
         this.searchInitialState = new LSMVCTreeCursorInitialState(lsmTree.getInteriorFrameFactory(),
                 lsmTree.getLeafFrameFactory(), lsmTree.getMetadataFrameFactory(), lsmTree.getDataFrameFactory(), null,
                 lsmTree.getHarness(), null, searchCallback, componentHolder);
@@ -99,12 +101,18 @@ public class LSMVCTreeOpContext extends AbstractLSMIndexOperationContext {
     }
 
     /**
+     * Gets the index access parameters.
+     */
+    public IIndexAccessParameters getIndexAccessParameters() {
+        return iap;
+    }
+
+    /**
      * Gets the accessor for the current mutable VectorClusteringTree component.
      */
     public ITreeIndexAccessor getCurrentMutableVCTreeAccessor() throws HyracksDataException {
         LSMVCTree lsmVCTree = (LSMVCTree) getIndex();
         LSMVCTreeMemoryComponent memComponent = (LSMVCTreeMemoryComponent) lsmVCTree.getCurrentMemoryComponent();
-        IndexAccessParameters iap = new IndexAccessParameters(getModificationCallback(), getSearchOperationCallback());
         return memComponent.getIndex().createAccessor(iap);
     }
 }

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeSearchCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeSearchCursor.java
@@ -176,7 +176,9 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
     protected VectorClusteringTreeAccessor createAccessor(ILSMComponent component, int index)
             throws HyracksDataException {
         VectorClusteringTree vcTree = (VectorClusteringTree) component.getIndex();
-        return (VectorClusteringTreeAccessor) vcTree.createAccessor(iap);
+        // Get iap from operation context instead of using cursor's default iap
+        LSMVCTreeOpContext vcOpCtx = (LSMVCTreeOpContext) opCtx;
+        return (VectorClusteringTreeAccessor) vcTree.createAccessor(vcOpCtx.getIndexAccessParameters());
     }
 
     /**

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeSearchCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeSearchCursor.java
@@ -19,405 +19,361 @@
 
 package org.apache.hyracks.storage.am.lsm.vector.impls;
 
-import java.util.Comparator;
-import java.util.List;
-import java.util.PriorityQueue;
-
 import org.apache.hyracks.api.exceptions.HyracksDataException;
+import org.apache.hyracks.api.util.CleanupUtils;
 import org.apache.hyracks.dataflow.common.data.accessors.ITupleReference;
 import org.apache.hyracks.storage.am.lsm.common.api.ILSMComponent;
+import org.apache.hyracks.storage.am.lsm.common.api.ILSMComponent.LSMComponentType;
 import org.apache.hyracks.storage.am.lsm.common.api.ILSMIndexOperationContext;
-import org.apache.hyracks.storage.am.lsm.common.impls.AbstractLSMIndexOperationContext;
-import org.apache.hyracks.storage.am.vector.impls.VectorClusteringSearchCursor;
+import org.apache.hyracks.storage.am.lsm.common.impls.LSMIndexSearchCursor;
 import org.apache.hyracks.storage.am.vector.impls.VectorClusteringTree;
-import org.apache.hyracks.storage.am.vector.impls.VectorRangePredicate;
-import org.apache.hyracks.storage.am.vector.util.VectorUtils;
+import org.apache.hyracks.storage.am.vector.impls.VectorClusteringTree.VectorClusteringTreeAccessor;
 import org.apache.hyracks.storage.common.ICursorInitialState;
 import org.apache.hyracks.storage.common.IIndexCursor;
+import org.apache.hyracks.storage.common.IIndexCursorStats;
 import org.apache.hyracks.storage.common.ISearchPredicate;
+import org.apache.hyracks.storage.common.MultiComparator;
+import org.apache.hyracks.storage.common.NoOpIndexCursorStats;
+import org.apache.hyracks.storage.common.util.IndexCursorUtils;
 
 /**
- * Search cursor for LSM Vector Clustering Tree.
+ * LSM search cursor for Vector Clustering Tree.
  *
- * This cursor coordinates search operations across multiple LSM components (memory and disk),
- * merging results using a priority queue to return top-k nearest neighbors based on vector similarity.
+ * This cursor coordinates searches across multiple LSM components (memory and disk)
+ * by delegating to VectorClusteringSearchCursor for each component and merging results.
  *
- * Algorithm Overview:
- * 1. Open cursors for all operational components (memory + disk)
- * 2. Each component cursor finds its closest cluster and iterates through cluster data
- * 3. Use a max-heap priority queue to maintain top-k results across all components
- * 4. Return results in ascending order of distance (nearest first)
+ * Following the pattern of LSMBTreeRangeSearchCursor:
+ * - Extends LSMIndexSearchCursor for priority queue and component switching infrastructure
+ * - Creates VectorClusteringTreeAccessor for each component
+ * - Handles component state changes (memory → disk transitions)
+ * - For vector index: simplified sequential iteration (no priority queue merging needed for now)
  */
-public class LSMVCTreeSearchCursor implements IIndexCursor {
+public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
 
-    private AbstractLSMIndexOperationContext opCtx;
-    private List<ILSMComponent> operationalComponents;
-    private List<IIndexCursor> rangeCursors;
+    // Accessor array for each component's VCTree
+    private VectorClusteringTreeAccessor[] vcTreeAccessors;
+
+    // Track component types to detect memory → disk transitions
+    protected boolean[] isMemoryComponent;
+
+    // Store search predicate for component switching
     private ISearchPredicate searchPredicate;
-    private VectorRangePredicate vectorPredicate;
 
-    // Cursor state
-    private boolean open;
-    private boolean exhausted;
-    private ITupleReference currentTuple;
-
-    // Priority queue for top-k results
-    private PriorityQueue<VectorResult> resultHeap;
-    private int k; // Number of results to return
-    private double[] queryVector;
-
-    // Result iteration
-    private VectorResult[] sortedResults;
-    private int resultIndex;
-
-    /**
-     * Internal class to hold vector search results with distance information.
-     */
-    private static class VectorResult {
-        final ITupleReference tuple;
-        final double distance;
-        final int componentIndex;
-
-        VectorResult(ITupleReference tuple, double distance, int componentIndex) {
-            this.tuple = tuple;
-            this.distance = distance;
-            this.componentIndex = componentIndex;
-        }
-    }
+    // Current component being iterated
+    private int currentComponentIndex;
+    private IIndexCursor currentComponentCursor;
 
     public LSMVCTreeSearchCursor(ILSMIndexOperationContext opCtx) {
-        this.opCtx = (AbstractLSMIndexOperationContext) opCtx;
-        this.open = false;
-        this.exhausted = false;
-        this.resultIndex = 0;
+        this(opCtx, false, NoOpIndexCursorStats.INSTANCE);
+    }
+
+    public LSMVCTreeSearchCursor(ILSMIndexOperationContext opCtx, boolean returnDeletedTuples,
+            IIndexCursorStats stats) {
+        super(opCtx, returnDeletedTuples, stats);
+        this.currentComponentIndex = 0;
+        this.currentComponentCursor = null;
     }
 
     @Override
-    public void open(ICursorInitialState initialState, ISearchPredicate searchPred) throws HyracksDataException {
+    public void doOpen(ICursorInitialState initialState, ISearchPredicate searchPred) throws HyracksDataException {
+        // Get LSM-specific initial state
         LSMVCTreeCursorInitialState lsmInitialState = (LSMVCTreeCursorInitialState) initialState;
 
+        // Save search predicate for component switching
         this.searchPredicate = searchPred;
-        this.operationalComponents = lsmInitialState.getOperationalComponents();
-        this.rangeCursors = lsmInitialState.getCursors();
 
-        // Extract vector search parameters
-        if (searchPred instanceof VectorRangePredicate) {
-            this.vectorPredicate = (VectorRangePredicate) searchPred;
-            this.queryVector = vectorPredicate.getQueryVector();
-            this.k = 10;
-        } else {
-            throw new HyracksDataException("LSMVCTreeSearchCursor requires VectorRangePredicate");
+        // Set up comparator and operational components
+        cmp = lsmInitialState.getOriginalKeyComparator();
+        operationalComponents = lsmInitialState.getOperationalComponents();
+        lsmHarness = lsmInitialState.getLSMHarness();
+
+        // For vector index, we don't need mutable component special handling initially
+        includeMutableComponent = false;
+
+        int numVCTrees = operationalComponents.size();
+
+        // Initialize or resize accessor/cursor arrays
+        if (rangeCursors == null) {
+            // First open: create arrays
+            rangeCursors = new IIndexCursor[numVCTrees];
+            vcTreeAccessors = new VectorClusteringTreeAccessor[numVCTrees];
+            isMemoryComponent = new boolean[numVCTrees];
+        } else if (rangeCursors.length != numVCTrees) {
+            // Component count changed (due to flush/merge): destroy and recreate
+            Throwable failure = CleanupUtils.destroy(null, vcTreeAccessors);
+            vcTreeAccessors = null;
+            failure = CleanupUtils.destroy(failure, rangeCursors);
+            if (failure != null) {
+                throw HyracksDataException.create(failure);
+            }
+            rangeCursors = new IIndexCursor[numVCTrees];
+            vcTreeAccessors = new VectorClusteringTreeAccessor[numVCTrees];
+            isMemoryComponent = new boolean[numVCTrees];
         }
 
-        // Initialize priority queue for top-k results (max-heap to keep smallest k distances)
-        this.resultHeap = new PriorityQueue<>(k + 1, new Comparator<VectorResult>() {
-            @Override
-            public int compare(VectorResult a, VectorResult b) {
-                // Max-heap: larger distances have higher priority (will be removed first)
-                return Double.compare(b.distance, a.distance);
-            }
-        });
-
-        this.open = true;
-        this.exhausted = false;
-        this.resultIndex = 0;
-        this.sortedResults = null;
-
-        // Open cursors for all operational components
-        openComponentCursors();
-
-        // Collect and merge results from all components
-        collectAndMergeResults();
-    }
-
-    /**
-     * Open cursors for all LSM components (memory and disk).
-     */
-    private void openComponentCursors() throws HyracksDataException {
-        for (int i = 0; i < operationalComponents.size(); i++) {
+        // Create accessors and cursors for each component
+        for (int i = 0; i < numVCTrees; i++) {
             ILSMComponent component = operationalComponents.get(i);
+            LSMComponentType type = component.getType();
 
-            if (component instanceof LSMVCTreeMemoryComponent) {
-                openMemoryComponentCursor(component, i);
-            } else if (component instanceof LSMVCTreeDiskComponent) {
-                openDiskComponentCursor(component, i);
+            // Track if this is a memory component
+            if (component.getType() == LSMComponentType.MEMORY) {
+                includeMutableComponent = true;
+            }
+
+            // Check if we need to destroy incompatible accessor/cursor
+            if (vcTreeAccessors[i] == null || destroyIncompatible(component, i)) {
+                vcTreeAccessors[i] = createAccessor(component, i);
+                rangeCursors[i] = createCursor(type, vcTreeAccessors[i]);
             } else {
-                throw new HyracksDataException("Unknown LSM component type: " + component.getClass());
+                // Re-use existing cursor
+                rangeCursors[i].close();
             }
-        }
-    }
 
-    /**
-     * Open cursor for memory component.
-     */
-    private void openMemoryComponentCursor(ILSMComponent component, int componentIndex) throws HyracksDataException {
-        LSMVCTreeMemoryComponent memComponent = (LSMVCTreeMemoryComponent) component;
-        VectorClusteringTree vcTree = memComponent.getIndex();
-
-        // Create and configure cursor
-        VectorClusteringSearchCursor vcCursor = (VectorClusteringSearchCursor) vcTree.createSearchCursor(false);
-        vcCursor.setBufferCache(vcTree.getBufferCache());
-        vcCursor.setFileId(vcTree.getFileId());
-        vcCursor.setRootPageId(vcTree.getRootPageId());
-        vcCursor.setFrameFactories(vcTree.getInteriorFrameFactory(), vcTree.getLeafFrameFactory(),
-                vcTree.getMetadataFrameFactory(), vcTree.getDataFrameFactory());
-        vcCursor.setQueryVector(queryVector);
-
-        rangeCursors.set(componentIndex, vcCursor);
-        vcCursor.open(null, searchPredicate);
-
-        System.out.println("DEBUG: Opened memory component cursor " + componentIndex);
-    }
-
-    /**
-     * Open cursor for disk component.
-     */
-    private void openDiskComponentCursor(ILSMComponent component, int componentIndex) throws HyracksDataException {
-        LSMVCTreeDiskComponent diskComponent = (LSMVCTreeDiskComponent) component;
-        VectorClusteringTree vcTree = diskComponent.getIndex();
-
-        // Create and configure cursor (same as memory component)
-        VectorClusteringSearchCursor vcCursor = (VectorClusteringSearchCursor) vcTree.createSearchCursor(false);
-        vcCursor.setBufferCache(vcTree.getBufferCache());
-        vcCursor.setFileId(vcTree.getFileId());
-        vcCursor.setRootPageId(vcTree.getRootPageId());
-        vcCursor.setFrameFactories(vcTree.getInteriorFrameFactory(), vcTree.getLeafFrameFactory(),
-                vcTree.getMetadataFrameFactory(), vcTree.getDataFrameFactory());
-        vcCursor.setQueryVector(queryVector);
-
-        rangeCursors.set(componentIndex, vcCursor);
-        vcCursor.open(null, searchPredicate);
-
-        System.out.println("DEBUG: Opened disk component cursor " + componentIndex);
-    }
-
-    /**
-     * Collect results from all component cursors and merge using priority queue.
-     */
-    private void collectAndMergeResults() throws HyracksDataException {
-        System.out.println("DEBUG: Collecting results from " + rangeCursors.size() + " components");
-
-        // Process results from each component cursor
-        for (int i = 0; i < rangeCursors.size(); i++) {
-            IIndexCursor cursor = rangeCursors.get(i);
-            if (cursor == null)
-                continue;
-
-            System.out.println("DEBUG: Processing component " + i);
-
-            // Collect all results from this component
-            while (cursor.hasNext()) {
-                cursor.next();
-                ITupleReference tuple = cursor.getTuple();
-
-                // Calculate distance from query vector to this result
-                double distance = calculateDistanceFromTuple(tuple, queryVector);
-
-                // Add to priority queue (implements top-k logic)
-                addToTopKResults(new VectorResult(tuple, distance, i));
-            }
+            isMemoryComponent[i] = type == LSMComponentType.MEMORY;
         }
 
-        // Convert priority queue to sorted array for iteration
-        prepareSortedResults();
+        // Open all cursors with the search predicate
+        IndexCursorUtils.open(vcTreeAccessors, rangeCursors, searchPred);
 
-        System.out.println("DEBUG: Collected " + (sortedResults != null ? sortedResults.length : 0) + " total results");
-    }
+        // Initialize sequential iteration
+        currentComponentIndex = 0;
+        currentComponentCursor = (rangeCursors.length > 0) ? rangeCursors[0] : null;
 
-    /**
-     * Add a result to the top-k priority queue.
-     */
-    private void addToTopKResults(VectorResult result) {
-        if (resultHeap.size() < k) {
-            // Queue not full, just add
-            resultHeap.offer(result);
-        } else {
-            // Queue full, check if this result is better than the worst
-            VectorResult worst = resultHeap.peek();
-            if (result.distance < worst.distance) {
-                // This result is better, replace worst
-                resultHeap.poll();
-                resultHeap.offer(result);
-            }
-        }
-    }
-
-    /**
-     * Convert priority queue to sorted array for iteration.
-     */
-    private void prepareSortedResults() {
-        if (resultHeap.isEmpty()) {
-            sortedResults = new VectorResult[0];
-            return;
-        }
-
-        // Extract all results from heap
-        sortedResults = resultHeap.toArray(new VectorResult[0]);
-
-        // Sort by distance (ascending order - nearest first)
-        java.util.Arrays.sort(sortedResults, new Comparator<VectorResult>() {
-            @Override
-            public int compare(VectorResult a, VectorResult b) {
-                return Double.compare(a.distance, b.distance);
-            }
-        });
-
-        System.out.println("DEBUG: Prepared " + sortedResults.length + " sorted results");
-        if (sortedResults.length > 0) {
-            System.out.println("DEBUG: Best distance: " + sortedResults[0].distance);
-            System.out.println("DEBUG: Worst distance: " + sortedResults[sortedResults.length - 1].distance);
-        }
-    }
-
-    /**
-     * Calculate Euclidean distance between query vector and a result tuple.
-     */
-    private double calculateDistanceFromTuple(ITupleReference tuple, double[] queryVector) {
+        // Note: Priority queue setup is kept for compatibility with base class,
+        // but not used in simplified sequential iteration
         try {
-            // Assuming tuple format: [distance, cosine_similarity, vector_data, primary_key]
-            // Extract vector data from field 2
-            byte[] vectorData = tuple.getFieldData(2);
-            int vectorOffset = tuple.getFieldStart(2);
-            int vectorLength = tuple.getFieldLength(2);
-
-            // Deserialize vector using FloatArraySerializerDeserializer
-            //TODO
-            double[] resultVector = new double[vectorLength / Float.BYTES];
-
-            // Calculate Euclidean distance
-            return VectorUtils.calculateEuclideanDistance(queryVector, resultVector);
-
-        } catch (Exception e) {
-            System.out.println(
-                    "WARNING: Failed to calculate distance for tuple, using distance field: " + e.getMessage());
-
-            // Fallback: try to use pre-calculated distance from field 0
-            try {
-                byte[] distanceData = tuple.getFieldData(0);
-                int distanceOffset = tuple.getFieldStart(0);
-                // TODO
-                return 0;
-            } catch (Exception e2) {
-                System.out.println("ERROR: Could not extract distance from tuple: " + e2.getMessage());
-                return Double.MAX_VALUE;
-            }
+            setPriorityQueueComparator();
+            initPriorityQueue();
+        } catch (Throwable th) { // NOSONAR Must catch all
+            IndexCursorUtils.close(rangeCursors, th);
+            throw HyracksDataException.create(th);
         }
     }
 
-    @Override
-    public boolean hasNext() throws HyracksDataException {
-        if (!open) {
-            return false;
-        }
-
-        if (exhausted) {
-            return false;
-        }
-
-        // Check if we have more results to return
-        if (sortedResults != null && resultIndex < sortedResults.length) {
+    /**
+     * Check if accessor/cursor needs to be destroyed due to component type change.
+     * This happens when a memory component is replaced with a disk component.
+     */
+    private boolean destroyIncompatible(ILSMComponent component, int index) throws HyracksDataException {
+        // XOR: if component type changed (memory → disk or disk → memory)
+        if (component.getType() == LSMComponentType.MEMORY ^ isMemoryComponent[index]) {
+            Throwable failure = CleanupUtils.destroy(null, vcTreeAccessors[index]);
+            vcTreeAccessors[index] = null;
+            failure = CleanupUtils.destroy(failure, rangeCursors[index]);
+            rangeCursors[index] = null;
+            if (failure != null) {
+                throw HyracksDataException.create(failure);
+            }
             return true;
         }
-
-        // No more results
-        exhausted = true;
         return false;
     }
 
+    /**
+     * Create accessor for a VCTree component.
+     */
+    protected VectorClusteringTreeAccessor createAccessor(ILSMComponent component, int index)
+            throws HyracksDataException {
+        VectorClusteringTree vcTree = (VectorClusteringTree) component.getIndex();
+        return (VectorClusteringTreeAccessor) vcTree.createAccessor(iap);
+    }
+
+    /**
+     * Create cursor for a VCTree component.
+     */
+    protected IIndexCursor createCursor(LSMComponentType type, VectorClusteringTreeAccessor accessor)
+            throws HyracksDataException {
+        return accessor.createSearchCursor(false);
+    }
+
     @Override
-    public void next() throws HyracksDataException {
-        if (!hasNext()) {
-            throw new IllegalStateException("No more elements");
+    public void doClose() throws HyracksDataException {
+        super.doClose();
+        // Additional cleanup specific to vector index if needed
+    }
+
+    @Override
+    public boolean doHasNext() throws HyracksDataException {
+        hasNextCallCount++;
+        checkPriorityQueue();
+        // Check sequential iteration state instead of priority queue
+        return currentComponentCursor != null && currentComponentCursor.hasNext();
+    }
+
+    @Override
+    public void doNext() throws HyracksDataException {
+        // Simplified version: just advance current component cursor
+        // No priority queue sorting needed - return all tuples from all components
+        if (currentComponentCursor != null && currentComponentCursor.hasNext()) {
+            currentComponentCursor.next();
+        }
+    }
+
+    @Override
+    protected void checkPriorityQueue() throws HyracksDataException {
+        // Every SWITCH_COMPONENT_CYCLE calls, check if memory components need to be swapped with disk components
+        // This handles the case where a memory component is flushed to disk while the cursor is active
+        if (hasNextCallCount >= SWITCH_COMPONENT_CYCLE) {
+            replaceMemoryComponentWithDiskComponentIfNeeded();
+            hasNextCallCount = 0;
         }
 
-        // Get next result from sorted array
-        VectorResult result = sortedResults[resultIndex];
-        currentTuple = result.tuple;
-        resultIndex++;
+        // Simplified version: sequential iteration through components
+        // No priority queue sorting - just return all tuples from all components in order
+        // TODO: Future optimization - use priority queue to merge results sorted by distance
+        //       for more efficient top-k selection at higher layers
 
-        System.out.println("DEBUG: Returning result " + resultIndex + " with distance " + result.distance
-                + " from component " + result.componentIndex);
+        // Find next component with results
+        while (currentComponentIndex < rangeCursors.length) {
+            if (currentComponentCursor != null && currentComponentCursor.hasNext()) {
+                // Current component still has results
+                return;
+            }
+
+            // Current component exhausted, move to next
+            currentComponentIndex++;
+            if (currentComponentIndex < rangeCursors.length) {
+                currentComponentCursor = rangeCursors[currentComponentIndex];
+            } else {
+                currentComponentCursor = null;
+            }
+        }
     }
 
-    @Override
-    public ITupleReference getTuple() {
-        return currentTuple;
-    }
-
-    @Override
-    public void close() throws HyracksDataException {
-        if (!open) {
+    /**
+     * Replace memory components with disk components if they were flushed.
+     * This is called periodically to handle concurrent flushes during search.
+     */
+    private void replaceMemoryComponentWithDiskComponentIfNeeded() throws HyracksDataException {
+        int replaceFrom = findFirstComponentToReplace();
+        if (replaceFrom < 0) {
+            // No switch needed
             return;
         }
 
-        // Close all component cursors
-        if (rangeCursors != null) {
-            for (IIndexCursor cursor : rangeCursors) {
-                if (cursor != null) {
-                    cursor.close();
+        // Ask LSM harness to replace memory components with their flushed disk versions
+        opCtx.getIndex().getHarness().replaceMemoryComponentsWithDiskComponents(getOpCtx(), replaceFrom);
+
+        // Redo searches on the new disk components
+        for (int i = replaceFrom; i < switchRequest.length && i < operationalComponents.size(); i++) {
+            if (switchRequest[i]) {
+                ILSMComponent component = operationalComponents.get(i);
+                VectorClusteringTree vcTree = (VectorClusteringTree) component.getIndex();
+
+                // Check if first component is now disk (no more mutable component)
+                if (i == 0 && component.getType() != LSMComponentType.MEMORY) {
+                    includeMutableComponent = false;
                 }
+
+                // If we had an active element from this component, restart search from that point
+                if (switchedElements[i] != null) {
+                    // Close cursor and reset accessor to the new disk component
+                    rangeCursors[i].close();
+                    vcTreeAccessors[i].reset(vcTree, iap);
+                    vcTreeAccessors[i].search(rangeCursors[i], searchPredicate);
+
+                    // Try to position cursor at the same element
+                    if (rangeCursors[i].hasNext()) {
+                        rangeCursors[i].next();
+                        switchedElements[i].reset(rangeCursors[i].getTuple());
+                    }
+                }
+            }
+            switchRequest[i] = false;
+            switchedElements[i] = null;
+            // Any failed switch makes further switches pointless
+            switchPossible = switchPossible && operationalComponents.get(i).getType() == LSMComponentType.DISK;
+        }
+    }
+
+    /**
+     * Find the first component that needs to be replaced (has been flushed).
+     * Returns the index of the first component to replace, or -1 if no replacement needed.
+     */
+    private int findFirstComponentToReplace() throws HyracksDataException {
+        int replaceFrom = -1;
+
+        if (!switchPossible) {
+            return replaceFrom;
+        }
+
+        for (int i = 0; i < operationalComponents.size(); i++) {
+            ILSMComponent component = operationalComponents.get(i);
+
+            if (component.getType() == LSMComponentType.DISK) {
+                if (i == 0) {
+                    // First component is already disk, no more switching possible
+                    switchPossible = false;
+                }
+                break;
+            } else if (component.getState() == ILSMComponent.ComponentState.UNREADABLE_UNWRITABLE) {
+                // Component was flushed while cursor is active - mark for replacement
+                if (replaceFrom < 0) {
+                    replaceFrom = i;
+                }
+
+                // Find the element from this cursor (if any)
+                PriorityQueueElement element = findElementInQueue(i);
+
+                // Mark this cursor for switching
+                rangeCursors[i].close();
+                switchRequest[i] = true;
+                switchedElements[i] = element;
             }
         }
 
-        // Clear data structures
-        if (resultHeap != null) {
-            resultHeap.clear();
+        return replaceFrom;
+    }
+
+    /**
+     * Find an element in the priority queue or output element from a specific cursor.
+     */
+    private PriorityQueueElement findElementInQueue(int cursorIndex) {
+        // Check if output element is from this cursor
+        if (outputElement != null && outputElement.getCursorIndex() == cursorIndex) {
+            return outputElement;
         }
 
-        sortedResults = null;
-        open = false;
-        exhausted = false;
-        currentTuple = null;
-        resultIndex = 0;
+        // Search in priority queue
+        for (PriorityQueueElement element : outputPriorityQueue) {
+            if (element.getCursorIndex() == cursorIndex) {
+                return element;
+            }
+        }
+
+        return null;
     }
 
     @Override
-    public void destroy() throws HyracksDataException {
-        close();
-
-        // Destroy all component cursors
-        if (rangeCursors != null) {
-            for (IIndexCursor cursor : rangeCursors) {
-                if (cursor != null) {
-                    cursor.destroy();
-                }
-            }
-            rangeCursors.clear();
+    protected void setPriorityQueueComparator() {
+        // For vector index: sort by distance (field 0 in tuple)
+        // Tuple format: <distance, cosine, embedding, pk>
+        if (pqCmp == null || pqCmp.getMultiComparator() != cmp) {
+            pqCmp = new PriorityQueueComparator(cmp);
         }
     }
 
-    /**
-     * Checks if the cursor is currently open.
-     */
-    public boolean isOpen() {
-        return open;
+    @Override
+    public ITupleReference doGetTuple() {
+        // Return tuple from current component cursor
+        if (currentComponentCursor != null) {
+            return currentComponentCursor.getTuple();
+        }
+        return null;
     }
 
-    /**
-     * Checks if the cursor is exhausted.
-     */
-    public boolean isExhausted() {
-        return exhausted;
+    @Override
+    protected int compare(MultiComparator cmp, ITupleReference tupleA, ITupleReference tupleB) throws HyracksDataException {
+        // For vector index: compare by distance (first field)
+        // This ensures results are sorted by distance (nearest first)
+        return cmp.compare(tupleA, tupleB);
     }
 
-    /**
-     * Get the number of results returned by this search.
-     */
-    public int getResultCount() {
-        return sortedResults != null ? sortedResults.length : 0;
-    }
-
-    /**
-     * Get the query vector used for this search.
-     */
-    public double[] getQueryVector() {
-        return queryVector;
-    }
-
-    /**
-     * Get the k value (number of nearest neighbors requested).
-     */
-    public int getK() {
-        return k;
+    @Override
+    protected boolean isDeleted(PriorityQueueElement element) {
+        // Vector index doesn't have delete markers in tuples
+        // (deletions handled at primary index level)
+        return false;
     }
 }

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeSearchCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeSearchCursor.java
@@ -366,7 +366,8 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
     }
 
     @Override
-    protected int compare(MultiComparator cmp, ITupleReference tupleA, ITupleReference tupleB) throws HyracksDataException {
+    protected int compare(MultiComparator cmp, ITupleReference tupleA, ITupleReference tupleB)
+            throws HyracksDataException {
         // For vector index: compare by distance (first field)
         // This ensures results are sorted by distance (nearest first)
         return cmp.compare(tupleA, tupleB);

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/PKOnlyTupleProjector.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/PKOnlyTupleProjector.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.hyracks.storage.am.lsm.vector.impls;
+
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.hyracks.dataflow.common.comm.io.ArrayTupleBuilder;
+import org.apache.hyracks.dataflow.common.data.accessors.ITupleReference;
+import org.apache.hyracks.storage.common.projection.ITupleProjector;
+
+/**
+ * Tuple projector that extracts only primary key fields from vector index search results.
+ *
+ * Vector index tuples contain: <distance, cosine, embedding, pk1, pk2, ...>
+ * This projector skips the secondary key fields (distance, cosine, embedding) and
+ * writes only the primary key fields to the output.
+ *
+ * This optimization avoids transferring large embedding vectors (4KB-16KB) when only
+ * primary keys are needed for subsequent primary index lookup.
+ */
+public class PKOnlyTupleProjector implements ITupleProjector {
+
+    private final int numSecondaryKeys;  // Number of fields to skip
+    private final int numPrimaryKeys;    // Number of PK fields to write
+
+    public PKOnlyTupleProjector(int numSecondaryKeys, int numPrimaryKeys) {
+        this.numSecondaryKeys = numSecondaryKeys;
+        this.numPrimaryKeys = numPrimaryKeys;
+    }
+
+    @Override
+    public ITupleReference project(ITupleReference tuple, DataOutput dos, ArrayTupleBuilder tb) throws IOException {
+        // Skip secondary key fields, write only primary key fields
+        // Example: tuple = <distance, cosine, embedding[1024], pk0>
+        //          numSecondaryKeys = 3 (distance, cosine, embedding)
+        //          numPrimaryKeys = 1 (pk0)
+        //          Result: write only pk0 to output
+
+        int totalFields = tuple.getFieldCount();
+        int startField = numSecondaryKeys;
+        int endField = numSecondaryKeys + numPrimaryKeys;
+
+        // Validate field bounds
+        if (endField > totalFields) {
+            throw new IOException("Invalid field range: trying to extract fields [" + startField + ", " + endField
+                    + ") from tuple with " + totalFields + " fields");
+        }
+
+        // Write only PK fields
+        for (int i = startField; i < endField; i++) {
+            dos.write(tuple.getFieldData(i), tuple.getFieldStart(i), tuple.getFieldLength(i));
+            tb.addFieldEndOffset();
+        }
+
+        return tuple;
+    }
+}

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/PKOnlyTupleProjector.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/PKOnlyTupleProjector.java
@@ -37,8 +37,8 @@ import org.apache.hyracks.storage.common.projection.ITupleProjector;
  */
 public class PKOnlyTupleProjector implements ITupleProjector {
 
-    private final int numSecondaryKeys;  // Number of fields to skip
-    private final int numPrimaryKeys;    // Number of PK fields to write
+    private final int numSecondaryKeys; // Number of fields to skip
+    private final int numPrimaryKeys; // Number of PK fields to write
 
     public PKOnlyTupleProjector(int numSecondaryKeys, int numPrimaryKeys) {
         this.numSecondaryKeys = numSecondaryKeys;

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/PKOnlyTupleProjectorFactory.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/PKOnlyTupleProjectorFactory.java
@@ -34,8 +34,8 @@ public class PKOnlyTupleProjectorFactory implements ITupleProjectorFactory {
 
     private static final long serialVersionUID = 1L;
 
-    private final int numSecondaryKeys;  // Number of fields to skip
-    private final int numPrimaryKeys;    // Number of PK fields to write
+    private final int numSecondaryKeys; // Number of fields to skip
+    private final int numPrimaryKeys; // Number of PK fields to write
 
     public PKOnlyTupleProjectorFactory(int numSecondaryKeys, int numPrimaryKeys) {
         this.numSecondaryKeys = numSecondaryKeys;

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/PKOnlyTupleProjectorFactory.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/PKOnlyTupleProjectorFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.hyracks.storage.am.lsm.vector.impls;
+
+import org.apache.hyracks.api.context.IHyracksTaskContext;
+import org.apache.hyracks.api.exceptions.HyracksDataException;
+import org.apache.hyracks.storage.common.projection.ITupleProjector;
+import org.apache.hyracks.storage.common.projection.ITupleProjectorFactory;
+
+/**
+ * Factory for creating PKOnlyTupleProjector instances.
+ *
+ * Used by vector index search operators to create projectors that extract only
+ * primary key fields from vector index search results, skipping secondary key fields
+ * (distance, cosine similarity, embedding vector).
+ */
+public class PKOnlyTupleProjectorFactory implements ITupleProjectorFactory {
+
+    private static final long serialVersionUID = 1L;
+
+    private final int numSecondaryKeys;  // Number of fields to skip
+    private final int numPrimaryKeys;    // Number of PK fields to write
+
+    public PKOnlyTupleProjectorFactory(int numSecondaryKeys, int numPrimaryKeys) {
+        this.numSecondaryKeys = numSecondaryKeys;
+        this.numPrimaryKeys = numPrimaryKeys;
+    }
+
+    @Override
+    public ITupleProjector createTupleProjector(IHyracksTaskContext context) throws HyracksDataException {
+        return new PKOnlyTupleProjector(numSecondaryKeys, numPrimaryKeys);
+    }
+}

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/utils/LSMVCTreeUtils.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/utils/LSMVCTreeUtils.java
@@ -30,7 +30,6 @@ import org.apache.hyracks.api.io.IIOManager;
 import org.apache.hyracks.control.common.controllers.NCConfig;
 import org.apache.hyracks.data.std.primitive.DoublePointable;
 import org.apache.hyracks.data.std.primitive.FixedLengthTypeTrait;
-import org.apache.hyracks.data.std.primitive.FloatPointable;
 import org.apache.hyracks.data.std.primitive.IntegerPointable;
 import org.apache.hyracks.data.std.primitive.VarLengthTypeTrait;
 import org.apache.hyracks.storage.am.common.api.IMetadataPageManagerFactory;

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/utils/LSMVCTreeUtils.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/utils/LSMVCTreeUtils.java
@@ -28,6 +28,7 @@ import org.apache.hyracks.api.exceptions.HyracksDataException;
 import org.apache.hyracks.api.io.FileReference;
 import org.apache.hyracks.api.io.IIOManager;
 import org.apache.hyracks.control.common.controllers.NCConfig;
+import org.apache.hyracks.data.std.primitive.DoublePointable;
 import org.apache.hyracks.data.std.primitive.FixedLengthTypeTrait;
 import org.apache.hyracks.data.std.primitive.FloatPointable;
 import org.apache.hyracks.data.std.primitive.IntegerPointable;
@@ -126,7 +127,7 @@ public class LSMVCTreeUtils {
 
         // Metadata frames need 2-field metadata tuples: <max_distance, page_pointer>
         ITypeTraits[] metadataTypeTraits = new ITypeTraits[2];
-        metadataTypeTraits[0] = FloatPointable.TYPE_TRAITS; // max distance (double) - Fixed 4 bytes
+        metadataTypeTraits[0] = DoublePointable.TYPE_TRAITS; // max distance (double) - Fixed 8 bytes
         metadataTypeTraits[1] = IntegerPointable.TYPE_TRAITS; // page pointer (int) - Fixed 4 bytes
 
         // Data frames need 4-field data tuples: <distance, cosine_similarity, vector, primary_key>


### PR DESCRIPTION
 1. Reference Pattern for Query Vectors

  Following RTree's design pattern:
  - Factory (static): Stored in IIndexAccessParameters during open()
  - Tuple reference (dynamic): Updated per-tuple in resetSearchPredicate()
  - Extraction (runtime): Happens in VectorClusteringTreeAccessor.search() when tuple is available

  Key Change: VectorPointPredicate now holds ITupleReference instead of extracted double[]

  2. IIndexAccessParameters Propagation Through LSM Layers

  Fixed the parameter flow by storing iap in the operation context:

  VectorSearchOperatorNodePushable
    → stores factory in iap.getParameters()

  LSMVCTree.createOpContext(iap)
    → LSMVCTreeOpContext now stores iap

  LSMVCTreeSearchCursor.createAccessor()
    → retrieves iap from opCtx.getIndexAccessParameters()

  VectorClusteringTreeAccessor
    → can now extract factory from iap

  Problem: The base LSMIndexSearchCursor creates its own IIndexAccessParameters via createNoOpParams(), discarding the operator's parameters.

  Solution: Modified LSMVCTreeOpContext to store the original iap and provide getIndexAccessParameters() accessor.

  3. Fixed Vector Index Resource Factory

  Location: Dataset.java:494-499

  Changed VECTOR case from using BTreeResourceFactoryProvider to VCTreeResourceFactoryProvider.INSTANCE, ensuring LSMVCTree is created instead of LSMBTree.

  4. Shared Static Structure File Management

  Location: LSMVCTreeFileManager.java

  Fixed cleanupAndGetValidFiles() to correctly handle the architectural fact that the hierarchical k-means static structure is built once and shared across all LSM
  components, not per-component.

  Key Changes:
  - Validate single .static_structure_vctree file once
  - All VCTree component references point to same static structure file
  - If static structure is invalid/missing, clean up all VCTree files
  - Added getStaticStructureFileReference() method for separate access

  Files Changed

  Core Changes

  1. LSMVCTreeOpContext.java
    - Added iap field to store IIndexAccessParameters
    - Updated constructor to accept and store iap
    - Added getIndexAccessParameters() getter
    - Updated getCurrentMutableVCTreeAccessor() to use stored iap
  2. LSMVCTree.java
    - Updated createOpContext() to pass iap to context constructor
  3. LSMVCTreeSearchCursor.java
    - Updated createAccessor() to retrieve iap from operation context
    - Passes correct iap to VectorClusteringTree.createAccessor()
  4. VectorPointPredicate.java
    - Simplified to hold double[] directly (after user's linter cleanup)
    - Removed tuple reference fields (handled in operator layer)
  5. VectorSearchOperatorNodePushable.java
    - Implemented addAdditionalIndexAccessorParams() to store factory
    - Stores IVectorBinaryAccessorFactory in iap.getParameters()
  6. Dataset.java
    - Added VCTreeResourceFactoryProvider import and static field
    - Fixed VECTOR case to use VCTreeResourceFactoryProvider.INSTANCE
  7. LSMVCTreeFileManager.java
    - Fixed cleanupAndGetValidFiles() for shared static structure
    - Added getStaticStructureFileReference() method
    - Updated static structure suffix to .static_structure_vctree

  Supporting Files

  8. VectorClusteringTree.java (VectorClusteringTreeAccessor)
    - Extracts query vector from predicate using factory from iap
    - Creates VectorCursorInitialState with extracted vector
    - Passes to VectorClusteringSearchCursor.open()

  Testing

  Verified Flow

  ✅ Query vector factory propagates through all layers✅ Factory extraction works in VectorClusteringTreeAccessor.search()✅ LSMVCTree is correctly opened instead of
  LSMBTree✅ Static structure file validation works correctly

  Known Issues

  ⚠️ k parameter and distance metric not yet passed (TODO )⚠️ 
  Architecture Notes

  The storage layer (VectorClusteringTree, cursors) receives clean double[] arrays and has no knowledge of AsterixDB's AOrderedList<ADouble> serialization format. This
  separation is achieved through:

  - IVectorBinaryAccessor: Parses binary vector data
  - IVectorBinaryAccessorFactory: Creates accessors (serializable, can cross layers)
  - Operator layer responsibility: Create appropriate factory for AsterixDB types

  IIndexAccessParameters Pattern

  Following established patterns in AsterixDB:
  - Operators create IIndexAccessParameters and populate with custom parameters
  - Parameters flow through LSM operation contexts
  - Storage layer extracts parameters from iap.getParameters() map
  - Used by RTree, BTree, and now VCTree

