### PR TITLE
cardinality of records in job 3 bug fix

### DIFF
--- a/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/operators/VCTreeBulkLoaderAndGroupingOperatorDescriptor.java
+++ b/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/operators/VCTreeBulkLoaderAndGroupingOperatorDescriptor.java
@@ -662,7 +662,7 @@ public class VCTreeBulkLoaderAndGroupingOperatorDescriptor extends AbstractSingl
                 if (writer != null && outputAppender != null) {
                     // Append tuple to output frame
 
-                    if (outputAppender.append(transformedTuple)) {
+                    if (!outputAppender.append(transformedTuple)) {
                         FrameUtils.flushFrame(outputAppender.getBuffer(), writer);
                         outputAppender.reset(new VSizeFrame(ctx), true);
                         outputAppender.append(transformedTuple);


### PR DESCRIPTION
Fix: Correct cardinality of records in job 3
Summary
Fixes a logic bug in VCTreeBulkLoaderAndGroupingOperatorDescriptor that affected record cardinality calculation in job 3.
Changes
Fixed condition check in frame appending logic: changed if (outputAppender.append(transformedTuple)) to if (!outputAppender.append(transformedTuple))
Ensures frame flushing occurs when append fails (returns false), not when it succeeds
Technical Details
The bug was in the frame output handling logic. The condition was inverted, causing frames to flush at the wrong time, which led to incorrect cardinality calculations for records in job 3.
File changed:
asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/operators/VCTreeBulkLoaderAndGroupingOperatorDescriptor.java