### PR TITLE
[BUG]When num_k is set to 100, only near half of clusters has data to be loaded.

### DIFF
--- a/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/optimizer/rules/am/IntroduceTopKAccessMethodRule.java
+++ b/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/optimizer/rules/am/IntroduceTopKAccessMethodRule.java
@@ -243,7 +243,18 @@ public class IntroduceTopKAccessMethodRule extends AbstractIntroduceAccessMethod
             return false;
         }
 
-        // 2. Get type environment for type checking
+        // 2. Check if there are filter predicates (SELECT operators) between ORDER and DATASOURCE_SCAN
+        // If yes, skip vector index optimization to avoid returning too few results
+        // Reason: Vector index partitions by similarity, not by other fields.
+        // Filtering top-k results by other predicates may yield insufficient results.
+        if (hasSelectOperatorInSubTree()) {
+            System.err.println("Query has WHERE clause (SELECT operator) - skipping vector index optimization");
+            System.err.println("Reason: Vector index + filters may return too few results");
+            context.addToDontApplySet(this, limitOp);
+            return false;
+        }
+
+        // 3. Get type environment for type checking
         typeEnvironment = context.getOutputTypeEnvironment(orderOp);
 
         // 3. Load dataset metadata (including vector indexes)
@@ -281,6 +292,44 @@ public class IntroduceTopKAccessMethodRule extends AbstractIntroduceAccessMethod
         context.addToDontApplySet(this, limitOp);
 
         return transformed;
+    }
+
+    /**
+     * Checks if there are any SELECT operators between ORDER and DATASOURCE_SCAN.
+     * SELECT operators represent WHERE clause predicates that filter rows.
+     *
+     * We skip vector index optimization when filters exist because:
+     * - Vector index returns top-k results partitioned by vector similarity
+     * - Applying additional filters (e.g., year > 2000) may yield too few results
+     * - Better to scan all data and apply filters, then sort by ANN distance
+     */
+    protected boolean hasSelectOperatorInSubTree() {
+        if (orderOp.getInputs().isEmpty()) {
+            return false;
+        }
+
+        // Traverse from ORDER down to DATASOURCE_SCAN
+        AbstractLogicalOperator currentOp = (AbstractLogicalOperator) orderOp.getInputs().get(0).getValue();
+
+        while (currentOp != null) {
+            if (currentOp.getOperatorTag() == LogicalOperatorTag.SELECT) {
+                // Found SELECT operator - query has WHERE clause
+                return true;
+            }
+
+            // Stop at DATASOURCE_SCAN
+            if (currentOp.getOperatorTag() == LogicalOperatorTag.DATASOURCESCAN) {
+                break;
+            }
+
+            // Continue to next child
+            if (currentOp.getInputs().isEmpty()) {
+                break;
+            }
+            currentOp = (AbstractLogicalOperator) currentOp.getInputs().get(0).getValue();
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
To make it reproduce, redirect log output to a file and use analyze_cluster_load.sh:
./analyze_cluster_load.sh log output.txt.

When we create index with num_k = 100, we have:
==================================================
Cluster Distribution Analysis:
==================================================
Cluster | Count  | Percentage | Bar Chart
--------|--------|------------|--------------------------------------------
      0 |      6 |         0% | ██
      1 |     17 |        .1% | ██
      2 |     57 |        .5% | █
      3 |      2 |         0% | ██
      4 |    613 |       6.1% | ███████████████████
      5 |      3 |         0% | ██
      6 |    167 |       1.6% | █████
      7 |     42 |        .4% | █
      8 |      9 |         0% | ██
      9 |     33 |        .3% | █
     10 |     56 |        .5% | █
     11 |    212 |       2.1% | ██████
     12 |    149 |       1.4% | ████
     13 |    248 |       2.4% | ███████
     14 |     10 |        .1% | ██
     15 |    270 |       2.7% | ████████
     16 |    199 |       1.9% | ██████
     17 |     44 |        .4% | █
     18 |     31 |        .3% | ██
     19 |    116 |       1.1% | ███
     20 |    109 |       1.0% | ███
     21 |    175 |       1.7% | █████
     22 |     55 |        .5% | █
     23 |     34 |        .3% | █
     24 |    179 |       1.7% | █████
     25 |    256 |       2.5% | ████████
     26 |     15 |        .1% | ██
     27 |   1279 |      12.7% | ████████████████████████████████████████
     28 |    343 |       3.4% | ██████████
     29 |    215 |       2.1% | ██████
     30 |    267 |       2.6% | ████████
     31 |    419 |       4.1% | █████████████
     32 |      5 |         0% | ██
     33 |    344 |       3.4% | ██████████
     34 |    217 |       2.1% | ██████
     35 |    481 |       4.8% | ███████████████
     36 |     11 |        .1% | ██
     37 |     28 |        .2% | ██
     38 |      1 |         0% | ██
     39 |      1 |         0% | ██
     40 |     12 |        .1% | ██
     41 |     24 |        .2% | ██
     42 |     11 |        .1% | ██
     43 |    277 |       2.7% | ████████
     44 |    196 |       1.9% | ██████
     45 |    560 |       5.6% | █████████████████
     46 |     24 |        .2% | ██
     47 |    163 |       1.6% | █████
     48 |     34 |        .3% | █
     49 |    505 |       5.0% | ███████████████
     50 |    213 |       2.1% | ██████
     51 |   1252 |      12.5% | ███████████████████████████████████████
     52 |      2 |         0% | ██
     53 |      1 |         0% | ██
     54 |      2 |         0% | ██
     55 |      6 |         0% | ██

==================================================
Summary Statistics:
==================================================
Total clusters: 56
Total records: 10000

Only cluster 0 ~ cluster 55 has data loading in.