### PR TITLE
dynamic query to select index dynamically

### DIFF
--- a/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/optimizer/rules/am/IntroduceTopKAccessMethodRule.java
+++ b/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/optimizer/rules/am/IntroduceTopKAccessMethodRule.java
@@ -72,6 +72,7 @@ public class IntroduceTopKAccessMethodRule extends AbstractIntroduceAccessMethod
     protected AbstractFunctionCallExpression annDistanceExpr = null;
     protected IVariableTypeEnvironment typeEnvironment = null;
     protected final OptimizableOperatorSubTree subTree = new OptimizableOperatorSubTree();
+    protected String queryDistanceMetric = null; // Distance metric from the query (e.g., "euclidean", "cosine")
 
     // Register vector index access method
     protected static Map<FunctionIdentifier, List<IAccessMethod>> accessMethods = new HashMap<>();
@@ -395,6 +396,25 @@ public class IntroduceTopKAccessMethodRule extends AbstractIntroduceAccessMethod
             return false;
         }
 
+        // Extract distance metric from ANN_DISTANCE function (arg2)
+        // ANN_DISTANCE(vectorField, queryVector, distanceMetric)
+        if (annDistanceExpr.getArguments().size() >= 3) {
+            try {
+                ILogicalExpression distanceMetricExpr = annDistanceExpr.getArguments().get(2).getValue();
+                queryDistanceMetric = AccessMethodUtils
+                        .getStringConstant(new org.apache.commons.lang3.mutable.MutableObject<>(distanceMetricExpr));
+                if (queryDistanceMetric != null) {
+                    queryDistanceMetric = VectorIndexAccessMethod.normalizeDistanceMetric(queryDistanceMetric);
+                    System.err.println("=== Extracted query distance metric: " + queryDistanceMetric + " ===");
+                }
+            } catch (Exception e) {
+                // If we can't extract the metric, continue without metric-aware selection
+                // This maintains backward compatibility
+                queryDistanceMetric = null;
+                System.err.println("=== Could not extract distance metric from query, using field-only matching ===");
+            }
+        }
+
         // Now analyze the ANN_DISTANCE function arguments
         AccessMethodAnalysisContext analysisCtx = new AccessMethodAnalysisContext();
 
@@ -464,7 +484,8 @@ public class IntroduceTopKAccessMethodRule extends AbstractIntroduceAccessMethod
 
     /**
      * Chooses the best vector index from candidates.
-     * For now, simply picks the first matching vector index.
+     * Prefers indexes with matching distance metrics when query metric is available.
+     * Falls back to first field match if no metric match is found.
      */
     protected void chooseVectorIndex(Map<IAccessMethod, AccessMethodAnalysisContext> analyzedAMs,
             List<Pair<IAccessMethod, Index>> result) {
@@ -478,16 +499,44 @@ public class IntroduceTopKAccessMethodRule extends AbstractIntroduceAccessMethod
         Iterator<Map.Entry<Index, List<Pair<Integer, Integer>>>> indexIt =
                 analysisCtx.getIteratorForIndexExprsAndVars();
 
+        Pair<IAccessMethod, Index> exactMatch = null; // Index with matching field AND metric
+        Pair<IAccessMethod, Index> fieldMatch = null; // Index with matching field only
+
         while (indexIt.hasNext()) {
             Map.Entry<Index, List<Pair<Integer, Integer>>> indexEntry = indexIt.next();
             Index index = indexEntry.getKey();
 
             if (index.getIndexType() == IndexType.VECTOR) {
-                // TODO: Add cost-based selection if multiple vector indexes exist
-                // For now, just use the first matching vector index
-                result.add(new Pair<>(VectorIndexAccessMethod.INSTANCE, index));
-                break;
+                // If query distance metric is available, check for metric compatibility
+                if (queryDistanceMetric != null && !queryDistanceMetric.isEmpty()) {
+                    String indexMetric = VectorIndexAccessMethod.getIndexDistanceMetric(index);
+                    if (queryDistanceMetric.equals(indexMetric)) {
+                        // Exact match: field name AND distance metric match
+                        exactMatch = new Pair<>(VectorIndexAccessMethod.INSTANCE, index);
+                        System.err.println("=== Found exact match: index " + index.getIndexName() + " with metric "
+                                + indexMetric + " ===");
+                        break; // Prefer exact match, use first one found
+                    } else {
+                        // Field matches but metric doesn't - store as fallback only if no exact match
+                        if (fieldMatch == null) {
+                            fieldMatch = new Pair<>(VectorIndexAccessMethod.INSTANCE, index);
+                        }
+                    }
+                } else {
+                    // No query metric available - use first field match (backward compatibility)
+                    result.add(new Pair<>(VectorIndexAccessMethod.INSTANCE, index));
+                    break;
+                }
             }
+        }
+
+        // Select best match: exact match preferred, fallback to field match
+        if (exactMatch != null) {
+            result.add(exactMatch);
+            System.err.println("=== Selected index with matching distance metric ===");
+        } else if (fieldMatch != null) {
+            result.add(fieldMatch);
+            System.err.println("=== Selected index with matching field (metric mismatch, may affect accuracy) ===");
         }
     }
 
@@ -544,6 +593,7 @@ public class IntroduceTopKAccessMethodRule extends AbstractIntroduceAccessMethod
         orderOp = null;
         annDistanceExpr = null;
         typeEnvironment = null;
+        queryDistanceMetric = null;
         subTree.reset();
     }
 

--- a/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/optimizer/rules/am/VectorIndexAccessMethod.java
+++ b/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/optimizer/rules/am/VectorIndexAccessMethod.java
@@ -27,6 +27,7 @@ import org.apache.asterix.common.annotations.AbstractExpressionAnnotationWithInd
 import org.apache.asterix.common.config.DatasetConfig.IndexType;
 import org.apache.asterix.metadata.entities.Dataset;
 import org.apache.asterix.metadata.entities.Index;
+import org.apache.asterix.object.base.AdmObjectNode;
 import org.apache.asterix.om.functions.BuiltinFunctions;
 import org.apache.asterix.om.types.ARecordType;
 import org.apache.asterix.om.types.ATypeTag;
@@ -296,6 +297,21 @@ public class VectorIndexAccessMethod implements IAccessMethod {
     @Override
     public boolean exprIsOptimizable(Index index, IOptimizableFuncExpr optFuncExpr, boolean checkApplicableOnly)
             throws AlgebricksException {
+        return exprIsOptimizable(index, optFuncExpr, checkApplicableOnly, null);
+    }
+
+    /**
+     * Checks if this ANN_DISTANCE expression can use the given vector index.
+     * Validates both field name and distance metric compatibility.
+     * 
+     * @param index The vector index to check
+     * @param optFuncExpr The optimizable function expression
+     * @param checkApplicableOnly Whether to only check applicability
+     * @param queryDistanceMetric The distance metric from the query (optional, for metric-aware matching)
+     * @return true if the index can be used, false otherwise
+     */
+    public boolean exprIsOptimizable(Index index, IOptimizableFuncExpr optFuncExpr, boolean checkApplicableOnly,
+            String queryDistanceMetric) throws AlgebricksException {
         // Check if this ANN_DISTANCE expression can use the given vector index
 
         if (index.getIndexType() != IndexType.VECTOR) {
@@ -318,7 +334,22 @@ public class VectorIndexAccessMethod implements IAccessMethod {
         }
 
         // Match field name
-        return indexKeyFieldNames.get(0).equals(fieldName);
+        if (!indexKeyFieldNames.get(0).equals(fieldName)) {
+            return false;
+        }
+
+        // If query distance metric is provided, check metric compatibility
+        if (queryDistanceMetric != null && !queryDistanceMetric.isEmpty()) {
+            String indexMetric = getIndexDistanceMetric(index);
+            String normalizedQueryMetric = normalizeDistanceMetric(queryDistanceMetric);
+            if (!normalizedQueryMetric.equals(indexMetric)) {
+                // Field matches but distance metric doesn't - reject this index
+                return false;
+            }
+        }
+
+        // Field name matches (and metric matches if provided)
+        return true;
     }
 
     @Override
@@ -345,5 +376,82 @@ public class VectorIndexAccessMethod implements IAccessMethod {
     @Override
     public int compareTo(IAccessMethod o) {
         return this.getName().compareTo(o.getName());
+    }
+
+    /**
+     * Normalizes a distance metric string to its canonical form.
+     * Handles aliases and case-insensitive matching.
+     * 
+     * Supported metrics and aliases:
+     * - "euclidean", "l2" → "euclidean"
+     * - "euclidean_squared", "l2_squared" → "euclidean_squared"
+     * - "manhattan", "manhattan distance", "l1" → "manhattan"
+     * - "cosine", "cosine similarity" → "cosine"
+     * - "dot" → "dot"
+     * 
+     * @param metric The distance metric string (may be null or empty)
+     * @return Normalized canonical metric name, or "euclidean" as default
+     */
+    public static String normalizeDistanceMetric(String metric) {
+        if (metric == null || metric.trim().isEmpty()) {
+            return "euclidean"; // Default metric
+        }
+
+        String normalized = metric.toLowerCase().trim();
+
+        // Map aliases to canonical names
+        switch (normalized) {
+            case "l2":
+                return "euclidean";
+            case "l2_squared":
+                return "euclidean_squared";
+            case "l1":
+            case "manhattan distance":
+                return "manhattan";
+            case "cosine similarity":
+                return "cosine";
+            case "euclidean":
+            case "euclidean_squared":
+            case "manhattan":
+            case "cosine":
+            case "dot":
+                return normalized; // Already canonical
+            default:
+                // Unknown metric, return as-is (will be handled by distance function)
+                return normalized;
+        }
+    }
+
+    /**
+     * Extracts and normalizes the distance metric from a vector index.
+     * 
+     * @param index The vector index
+     * @return Normalized distance metric string, or "euclidean" as default
+     */
+    public static String getIndexDistanceMetric(Index index) {
+        if (index.getIndexType() != IndexType.VECTOR) {
+            return "euclidean"; // Default for non-vector indexes
+        }
+
+        Index.VectorIndexDetails vectorDetails = (Index.VectorIndexDetails) index.getIndexDetails();
+        AdmObjectNode withObjectNode = vectorDetails.getWithObjectNode();
+
+        String indexMetric =
+                (withObjectNode != null) ? withObjectNode.getOptionalString("similarity", "euclidean") : "euclidean";
+
+        return normalizeDistanceMetric(indexMetric);
+    }
+
+    /**
+     * Checks if two distance metrics are compatible (same canonical form).
+     * 
+     * @param metric1 First distance metric
+     * @param metric2 Second distance metric
+     * @return true if metrics are compatible, false otherwise
+     */
+    public static boolean areDistanceMetricsCompatible(String metric1, String metric2) {
+        String normalized1 = normalizeDistanceMetric(metric1);
+        String normalized2 = normalizeDistanceMetric(metric2);
+        return normalized1.equals(normalized2);
     }
 }

--- a/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/entitytupletranslators/IndexTupleTranslator.java
+++ b/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/entitytupletranslators/IndexTupleTranslator.java
@@ -49,7 +49,9 @@ import org.apache.asterix.metadata.entities.Datatype;
 import org.apache.asterix.metadata.entities.Index;
 import org.apache.asterix.metadata.utils.Creator;
 import org.apache.asterix.metadata.utils.KeyFieldTypeUtil;
+import org.apache.asterix.object.base.AdmBigIntNode;
 import org.apache.asterix.object.base.AdmObjectNode;
+import org.apache.asterix.object.base.AdmStringNode;
 import org.apache.asterix.om.base.ABoolean;
 import org.apache.asterix.om.base.ACollectionCursor;
 import org.apache.asterix.om.base.AInt32;
@@ -469,9 +471,10 @@ public class IndexTupleTranslator extends AbstractTupleTranslator<Index> {
 
                 excludeUnknownKey = OptionalBoolean.empty();
                 castDefaultNull = OptionalBoolean.empty();
+                AdmObjectNode withObjectNode = readWithProperties(indexRecord);
                 indexDetails = new Index.VectorIndexDetails(keyFieldNames.getFirst(), keyFieldNames,
                         keyFieldSourceIndicator, keyFieldTypes, isOverridingKeyTypes, excludeUnknownKey,
-                        castDefaultNull, null, null, null, null);
+                        castDefaultNull, null, null, null, withObjectNode);
                 break;
             case TEXT:
                 keyFieldNames =
@@ -858,6 +861,78 @@ public class IndexTupleTranslator extends AbstractTupleTranslator<Index> {
         aString.setValue(similarity);
         stringSerde.serialize(aString, fieldValue.getDataOutput());
         recordBuilder.addField(nameValue, fieldValue);
+    }
+
+    private AdmObjectNode readWithProperties(ARecord indexRecord) throws AlgebricksException {
+        // Default values (matching writeWithProperties defaults)
+        int dimension = -1;
+        int train_list = -1;
+        String description = "default";
+        String similarity = "euclidean";
+
+        // Read dimension field
+        int dimensionPos = indexRecord.getType().getFieldIndex("dimension");
+        if (dimensionPos >= 0) {
+            IAObject dimensionObj = indexRecord.getValueByPos(dimensionPos);
+            if (dimensionObj != null && dimensionObj.getType().getTypeTag() == ATypeTag.INTEGER) {
+                dimension = ((AInt32) dimensionObj).getIntegerValue();
+            }
+        }
+
+        // Read train_list field
+        int trainListPos = indexRecord.getType().getFieldIndex("train_list");
+        if (trainListPos >= 0) {
+            IAObject trainListObj = indexRecord.getValueByPos(trainListPos);
+            if (trainListObj != null && trainListObj.getType().getTypeTag() == ATypeTag.INTEGER) {
+                train_list = ((AInt32) trainListObj).getIntegerValue();
+            }
+        }
+
+        // Read description field
+        int descriptionPos = indexRecord.getType().getFieldIndex("description");
+        if (descriptionPos >= 0) {
+            IAObject descriptionObj = indexRecord.getValueByPos(descriptionPos);
+            if (descriptionObj != null && descriptionObj.getType().getTypeTag() == ATypeTag.STRING) {
+                description = ((AString) descriptionObj).getStringValue();
+            }
+        }
+
+        // Read similarity field
+        int similarityPos = indexRecord.getType().getFieldIndex("similarity");
+        if (similarityPos >= 0) {
+            IAObject similarityObj = indexRecord.getValueByPos(similarityPos);
+            if (similarityObj != null && similarityObj.getType().getTypeTag() == ATypeTag.STRING) {
+                similarity = ((AString) similarityObj).getStringValue();
+            }
+        }
+
+        // Reconstruct AdmObjectNode only if at least one field differs from default
+        boolean hasNonDefaultValues = (dimension != -1) || (train_list != -1) || !"default".equals(description)
+                || !"euclidean".equals(similarity);
+
+        if (!hasNonDefaultValues) {
+            return null;
+        }
+
+        AdmObjectNode withObjectNode = new AdmObjectNode();
+
+        if (dimension != -1) {
+            withObjectNode.set("dimension", new AdmBigIntNode(dimension));
+        }
+
+        if (train_list != -1) {
+            withObjectNode.set("train_list", new AdmBigIntNode(train_list));
+        }
+
+        if (!"default".equals(description)) {
+            withObjectNode.set("description", new AdmStringNode(description));
+        }
+
+        if (!"euclidean".equals(similarity)) {
+            withObjectNode.set("similarity", new AdmStringNode(similarity));
+        }
+
+        return withObjectNode;
     }
 
     private void writeIncludeFields(Index.VectorIndexDetails index) throws HyracksDataException {

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VCTreeBulkLoader.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VCTreeBulkLoader.java
@@ -496,7 +496,7 @@ public class VCTreeBulkLoader extends AbstractTreeIndexBulkLoader {
         // which wrote the page but didn't create a directory entry.
         // This made the last records inaccessible during search.
         if (entriesInCurrentDataPage > 0) {
-            writeDataPageToDirectory(true);  // Creates directory entry AND writes page
+            writeDataPageToDirectory(true); // Creates directory entry AND writes page
         }
 
         // Write the directory page

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/utils/VCTreeNavigationUtils.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/utils/VCTreeNavigationUtils.java
@@ -289,7 +289,7 @@ public class VCTreeNavigationUtils {
                 // For the first page, use the frame passed by caller (already pinned/latched)
                 // For overflow pages, pin and latch them ourselves
                 if (!isFirstPage) {
-                     currentPage = bufferCache.pin(BufferedFileHandle.getDiskPageId(fileId, currentPageId));
+                    currentPage = bufferCache.pin(BufferedFileHandle.getDiskPageId(fileId, currentPageId));
                     currentPage.acquireReadLatch();
                     currentFrame = (IVectorClusteringLeafFrame) leafFrameFactory.createFrame();
                     currentFrame.setPage(currentPage);

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/utils/LSMVCTreeUtils.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/utils/LSMVCTreeUtils.java
@@ -133,7 +133,7 @@ public class LSMVCTreeUtils {
         ITypeTraits[] dataTypeTraits = new ITypeTraits[3];
         dataTypeTraits[0] = new FixedLengthTypeTrait(9); // distance (double) - Fixed 8 bytes
         dataTypeTraits[1] = new FixedLengthTypeTrait(5); // cosine similarity (double) - Fixed 8 bytes
-//        dataTypeTraits[2] = VarLengthTypeTrait.INSTANCE; // vector (float array) - Variable
+        //        dataTypeTraits[2] = VarLengthTypeTrait.INSTANCE; // vector (float array) - Variable
         dataTypeTraits[2] = new FixedLengthTypeTrait(9); // primary key (string/variable) - Variable
 
         // Create individual tuple writer factories with correct type traits for each frame type

--- a/hyracks-fullstack/hyracks/hyracks-test-support/src/main/java/org/apache/hyracks/storage/am/vector/VectorTreeUtils.java
+++ b/hyracks-fullstack/hyracks/hyracks-test-support/src/main/java/org/apache/hyracks/storage/am/vector/VectorTreeUtils.java
@@ -90,7 +90,7 @@ public class VectorTreeUtils {
         ITypeTraits[] dataTypeTraits = new ITypeTraits[3];
         dataTypeTraits[0] = DoublePointable.TYPE_TRAITS; // distance (double) - Fixed 8 bytes
         dataTypeTraits[1] = DoublePointable.TYPE_TRAITS; // cosine similarity (double) - Fixed 8 bytes
-//        dataTypeTraits[2] = VarLengthTypeTrait.INSTANCE; // vector (float array) - Variable
+        //        dataTypeTraits[2] = VarLengthTypeTrait.INSTANCE; // vector (float array) - Variable
         dataTypeTraits[2] = VarLengthTypeTrait.INSTANCE; // primary key (string/variable) - Variable
 
         // Create individual tuple writer factories with correct type traits for each frame type


### PR DESCRIPTION
Dynamic Index Selection for Vector Queries
Summary
Makes index selection dynamic in vector queries, removing hardcoded index references and enabling runtime selection based on query context and available indexes.
Changes
IntroduceTopKAccessMethodRule.java (+60 lines)
Dynamic index selection for top-K vector queries
Runtime index resolution instead of hardcoded index names
VectorIndexAccessMethod.java (+112 lines)
Enhanced vector index access method with dynamic index lookup
Query-time index selection based on query predicates and available indexes
IndexTupleTranslator.java (+77 lines)
Index metadata translation updates to support dynamic index resolution
Improved handling of index metadata for runtime index selection
Utility Files (minor updates)
VCTreeBulkLoader.java, VCTreeNavigationUtils.java, LSMVCTreeUtils.java, VectorTreeUtils.java
Minor updates to support dynamic index selection
Impact
Enables runtime index selection for vector queries
Removes hardcoded index dependencies
Improves flexibility for queries with multiple vector indexes
Better support for dynamic query optimization
Testing
Verify dynamic index selection works with multiple vector indexes
Confirm top-K queries select appropriate indexes at runtime
Test index metadata translation with dynamic selection
Related Issues
Addresses hardcoded index selection limitations
Builds on previous work: dynamic distance functions (#66), multi-cluster ANN search (#68)
