### PR TITLE
Fix: interior page free space handle bug (wrong header size)

### DIFF
--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/frames/VectorClusteringInteriorFrame.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/frames/VectorClusteringInteriorFrame.java
@@ -44,6 +44,18 @@ public class VectorClusteringInteriorFrame extends VectorClusteringNSMFrame impl
         this.cmpFrameTuple = tupleWriter.createTupleReference();
     }
 
+    @Override
+    public void initBuffer(byte level) {
+        super.initBuffer(level);
+        buf.putInt(NEXT_PAGE_OFFSET, -1); // Initialize next page pointer to -1
+    }
+
+    @Override
+    public int getPageHeaderSize() {
+        // Include all header fields: base header + cluster ID + centroid ID + next page + overflow flag
+        return OVERFLOW_FLAG_OFFSET + 1;
+    }
+
     public void setOverflowFlagBit(boolean overflowFlag) {
         buf.put(OVERFLOW_FLAG_OFFSET, (byte) (overflowFlag ? 1 : 0));
     }


### PR DESCRIPTION
Tuple 0 data started at offset that overlapped with NEXT_PAGE and OVERFLOW_FLAG fields;
 When overflow pages were created setNextPage(25) overwrote tuple 0's data;
 Reading tuple 0 threw EOFException due to corrupted data;