### PR TITLE
Add dynamic primary key and include field support for vector index metadata

### DIFF
--- a/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/utils/VCTreeResourceFactoryProvider.java
+++ b/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/utils/VCTreeResourceFactoryProvider.java
@@ -37,6 +37,7 @@ import org.apache.asterix.om.types.ARecordType;
 import org.apache.asterix.om.types.ATypeTag;
 import org.apache.asterix.om.types.BuiltinType;
 import org.apache.asterix.om.types.IAType;
+import org.apache.asterix.dataflow.data.common.AOrderedListVectorBinaryAccessorFactory;
 import org.apache.hyracks.algebricks.common.exceptions.AlgebricksException;
 import org.apache.hyracks.algebricks.common.utils.Pair;
 import org.apache.hyracks.algebricks.data.IBinaryComparatorFactoryProvider;
@@ -138,11 +139,15 @@ public class VCTreeResourceFactoryProvider implements IResourceFactoryProvider {
         if (dataset.getDatasetType() == DatasetType.INTERNAL) {
             AsterixVirtualBufferCacheProvider vbcProvider =
                     new AsterixVirtualBufferCacheProvider(dataset.getDatasetId());
+            // Create vector accessor factory for extracting vectors from ADM ordered lists
+            AOrderedListVectorBinaryAccessorFactory vectorAccessorFactory =
+                    new AOrderedListVectorBinaryAccessorFactory();
             return new LSMVCTreeLocalResourceFactory(storageManager, typeTraits, cmpFactories, filterTypeTraits,
                     filterCmpFactories, filterFields, opTrackerFactory, ioOpCallbackFactory, pageWriteCallbackFactory,
                     metadataPageManagerFactory, vbcProvider, ioSchedulerProvider, mergePolicyFactory,
                     mergePolicyProperties, true, vectorDimensions, vectorFields,
-                    typeTraitProvider.getTypeTrait(BuiltinType.ANULL), NullIntrospector.INSTANCE, dataset.isAtomic());
+                    typeTraitProvider.getTypeTrait(BuiltinType.ANULL), NullIntrospector.INSTANCE, false,
+                    vectorAccessorFactory);
         } else {
             return null;
         }
@@ -152,45 +157,60 @@ public class VCTreeResourceFactoryProvider implements IResourceFactoryProvider {
             ARecordType recordType, ARecordType metaType) throws AlgebricksException {
         ITypeTraitProvider ttProvider = metadataProvider.getStorageComponentProvider().getTypeTraitProvider();
         Index.VectorIndexDetails vectorIndexDetails = (Index.VectorIndexDetails) index.getIndexDetails();
-        List<List<String>> keyFieldNames = vectorIndexDetails.getKeyFieldNames();
-        int numKeyFields = keyFieldNames.size();
         int numPrimaryKeys = dataset.getPrimaryKeys().size();
         ITypeTraits[] primaryTypeTraits = dataset.getPrimaryTypeTraits(metadataProvider, recordType, metaType);
 
-        if (numKeyFields != 1) {
-            throw new CompilationException(ErrorCode.COMPILATION_ILLEGAL_INDEX_NUM_OF_FIELD, numKeyFields,
-                    index.getIndexType(), 1);
-        }
+        // Get INCLUDE fields (optional)
+        List<List<String>> includeFieldNames = vectorIndexDetails.getIncludeFieldNames();
+        int numIncludeFields = (includeFieldNames != null) ? includeFieldNames.size() : 0;
 
-        // Get vector field type
-        List<String> vectorFieldNames = keyFieldNames.get(0);
+        // Data frame tuple format: [distance, centroidId, primary_keys..., include_fields...]
+        // This matches what VCTreeBulkLoaderAndGroupingOperatorDescriptor creates
+        int totalFields = 2 + numPrimaryKeys + numIncludeFields;
+        ITypeTraits[] typeTraits = new ITypeTraits[totalFields];
 
-        // Try to get the actual field type from the schema first (for closed fields)
-        IAType vectorFieldType = null;
-        try {
-            vectorFieldType = recordType.getSubFieldType(vectorFieldNames);
-        } catch (AlgebricksException e) {
-            // Field not found in schema, will use default for open fields
-            vectorFieldType = null;
-        }
+        // Field 0: distance (DOUBLE with ADM type tag)
+        typeTraits[0] = ttProvider.getTypeTrait(BuiltinType.ADOUBLE);
 
-        // If field type is not found in schema (open field), provide default type
-        if (vectorFieldType == null) {
-            vectorFieldType = DefaultOpenFieldType.getDefaultOpenFieldType(ATypeTag.ARRAY);
-        }
+        // Field 1: centroidId (INT32 with ADM type tag)
+        typeTraits[1] = ttProvider.getTypeTrait(BuiltinType.AINT32);
 
-        Pair<IAType, Boolean> vectorTypePair =
-                Index.getNonNullableOpenFieldType(index, vectorFieldType, vectorFieldNames, recordType);
-        IAType vectorType = vectorTypePair.first;
-        if (vectorType == null) {
-            throw new CompilationException(ErrorCode.COMPILATION_FIELD_NOT_FOUND, vectorFieldNames.toString());
-        }
-
-        // Create type traits for vector field + primary keys
-        ITypeTraits[] typeTraits = new ITypeTraits[numKeyFields + numPrimaryKeys];
-        typeTraits[0] = ttProvider.getTypeTrait(vectorType); // Vector field
+        // Fields 2+: Primary keys
         for (int i = 0; i < numPrimaryKeys; i++) {
-            typeTraits[numKeyFields + i] = primaryTypeTraits[i];
+            typeTraits[2 + i] = primaryTypeTraits[i];
+        }
+
+        // Fields after primary keys: INCLUDE fields (if any)
+        if (numIncludeFields > 0) {
+            List<IAType> includeFieldTypes = vectorIndexDetails.getIncludeFieldTypes();
+            List<Integer> includeSourceIndicators = vectorIndexDetails.getIncludeFieldSourceIndicators();
+
+            for (int i = 0; i < numIncludeFields; i++) {
+                IAType includeFieldType = null;
+
+                // Get field type from index details
+                if (includeFieldTypes != null && i < includeFieldTypes.size()) {
+                    includeFieldType = includeFieldTypes.get(i);
+                } else {
+                    // Fallback: try to get from record type
+                    List<String> includeFieldName = includeFieldNames.get(i);
+                    ARecordType sourceType = (includeSourceIndicators == null || includeSourceIndicators.get(i) == 0)
+                            ? recordType : metaType;
+                    try {
+                        includeFieldType = sourceType.getSubFieldType(includeFieldName);
+                    } catch (AlgebricksException e) {
+                        // Use default for open fields
+                        includeFieldType = DefaultOpenFieldType.getDefaultOpenFieldType(ATypeTag.ANY);
+                    }
+                }
+
+                if (includeFieldType == null) {
+                    throw new CompilationException(ErrorCode.COMPILATION_FIELD_NOT_FOUND,
+                            includeFieldNames.get(i).toString());
+                }
+
+                typeTraits[2 + numPrimaryKeys + i] = ttProvider.getTypeTrait(includeFieldType);
+            }
         }
 
         return typeTraits;
@@ -201,48 +221,61 @@ public class VCTreeResourceFactoryProvider implements IResourceFactoryProvider {
         IBinaryComparatorFactoryProvider cmpFactoryProvider =
                 metadataProvider.getStorageComponentProvider().getComparatorFactoryProvider();
         Index.VectorIndexDetails vectorIndexDetails = (Index.VectorIndexDetails) index.getIndexDetails();
-        List<List<String>> keyFieldNames = vectorIndexDetails.getKeyFieldNames();
-        int numKeyFields = keyFieldNames.size();
         int numPrimaryKeys = dataset.getPrimaryKeys().size();
 
-        if (numKeyFields != 1) {
-            throw new CompilationException(ErrorCode.COMPILATION_ILLEGAL_INDEX_NUM_OF_FIELD, numKeyFields,
-                    index.getIndexType(), 1);
-        }
+        // Get INCLUDE fields (optional)
+        List<List<String>> includeFieldNames = vectorIndexDetails.getIncludeFieldNames();
+        int numIncludeFields = (includeFieldNames != null) ? includeFieldNames.size() : 0;
 
-        // Get vector field type
-        List<String> vectorFieldNames = keyFieldNames.get(0);
+        // Data frame comparators: [distance, centroidId, primary_keys..., include_fields...]
+        // We need comparators for fields used in comparisons (typically distance and primary keys)
+        int totalFields = 2 + numPrimaryKeys + numIncludeFields;
+        IBinaryComparatorFactory[] cmpFactories = new IBinaryComparatorFactory[totalFields];
 
-        // Try to get the actual field type from the schema first (for closed fields)
-        IAType vectorFieldType = null;
-        try {
-            vectorFieldType = recordType.getSubFieldType(vectorFieldNames);
-        } catch (AlgebricksException e) {
-            // Field not found in schema, will use default for open fields
-            vectorFieldType = null;
-        }
+        // Comparator 0: distance (DOUBLE)
+        cmpFactories[0] = cmpFactoryProvider.getBinaryComparatorFactory(BuiltinType.ADOUBLE, true);
 
-        // If field type is not found in schema (open field), provide default type
-        if (vectorFieldType == null) {
-            vectorFieldType = DefaultOpenFieldType.getDefaultOpenFieldType(ATypeTag.ARRAY);
-        }
+        // Comparator 1: centroidId (INT32)
+        cmpFactories[1] = cmpFactoryProvider.getBinaryComparatorFactory(BuiltinType.AINT32, true);
 
-        Pair<IAType, Boolean> vectorTypePair =
-                Index.getNonNullableOpenFieldType(index, vectorFieldType, vectorFieldNames, recordType);
-        IAType vectorType = vectorTypePair.first;
-        if (vectorType == null) {
-            throw new CompilationException(ErrorCode.COMPILATION_FIELD_NOT_FOUND, vectorFieldNames.toString());
-        }
-
-        // Create comparator factories for vector field + primary keys
-        IBinaryComparatorFactory[] cmpFactories = new IBinaryComparatorFactory[numKeyFields + numPrimaryKeys];
-        cmpFactories[0] = cmpFactoryProvider.getBinaryComparatorFactory(vectorType, true); // Vector field
-
-        // Add primary key comparator factories
+        // Comparators 2+: Primary keys
         IBinaryComparatorFactory[] primaryComparatorFactories =
                 dataset.getPrimaryComparatorFactories(metadataProvider, recordType, metaType);
         for (int i = 0; i < numPrimaryKeys; i++) {
-            cmpFactories[numKeyFields + i] = primaryComparatorFactories[i];
+            cmpFactories[2 + i] = primaryComparatorFactories[i];
+        }
+
+        // Comparators after primary keys: INCLUDE fields (if any)
+        if (numIncludeFields > 0) {
+            List<IAType> includeFieldTypes = vectorIndexDetails.getIncludeFieldTypes();
+            List<Integer> includeSourceIndicators = vectorIndexDetails.getIncludeFieldSourceIndicators();
+
+            for (int i = 0; i < numIncludeFields; i++) {
+                IAType includeFieldType = null;
+
+                // Get field type from index details
+                if (includeFieldTypes != null && i < includeFieldTypes.size()) {
+                    includeFieldType = includeFieldTypes.get(i);
+                } else {
+                    // Fallback: try to get from record type
+                    List<String> includeFieldName = includeFieldNames.get(i);
+                    ARecordType sourceType = (includeSourceIndicators == null || includeSourceIndicators.get(i) == 0)
+                            ? recordType : metaType;
+                    try {
+                        includeFieldType = sourceType.getSubFieldType(includeFieldName);
+                    } catch (AlgebricksException e) {
+                        // Use default for open fields
+                        includeFieldType = DefaultOpenFieldType.getDefaultOpenFieldType(ATypeTag.ANY);
+                    }
+                }
+
+                if (includeFieldType == null) {
+                    throw new CompilationException(ErrorCode.COMPILATION_FIELD_NOT_FOUND,
+                            includeFieldNames.get(i).toString());
+                }
+
+                cmpFactories[2 + numPrimaryKeys + i] = cmpFactoryProvider.getBinaryComparatorFactory(includeFieldType, true);
+            }
         }
 
         return cmpFactories;

--- a/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/operators/VCTreeSortedDataBulkLoaderOperatorDescriptor.java
+++ b/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/operators/VCTreeSortedDataBulkLoaderOperatorDescriptor.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.asterix.dataflow.data.common.AOrderedListVectorBinaryAccessorFactory;
 import org.apache.asterix.om.base.ADouble;
 import org.apache.asterix.om.base.AInt32;
 import org.apache.hyracks.api.comm.IFrameWriter;
@@ -252,15 +253,19 @@ public class VCTreeSortedDataBulkLoaderOperatorDescriptor extends AbstractSingle
                     }
                 }
 
+                // Create vector accessor factory for extracting vectors from ADM ordered lists
+                AOrderedListVectorBinaryAccessorFactory vectorAccessorFactory =
+                        new AOrderedListVectorBinaryAccessorFactory();
+
                 // Create LSMVCTree using LSMVCTreeUtils (full version like in tests)
                 System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
                         + "] VCTreeSortedDataBulkLoader: About to call LSMVCTreeUtils.createLSMTree()");
                 lsmvcTree = LSMVCTreeUtils.createLSMTree(ncConfig, ioManager, virtualBufferCaches, file,
-                        diskBufferCache, typeTraits, cmpFactories, -1, new NoMergePolicy(), new ThreadCountingTracker(),
+                        diskBufferCache, typeTraits, cmpFactories, 0.0, new NoMergePolicy(), new ThreadCountingTracker(),
                         SynchronousSchedulerProvider.INSTANCE.getIoScheduler(null),
                         NoOpIOOperationCallbackFactory.INSTANCE, NoOpPageWriteCallbackFactory.INSTANCE, false,
                         vectorDimensions, vectorFields, filterFields, null, null, null, durable,
-                        AppendOnlyLinkedMetadataPageManagerFactory.INSTANCE, false, inputRecDesc);
+                        AppendOnlyLinkedMetadataPageManagerFactory.INSTANCE, false, inputRecDesc, vectorAccessorFactory);
 
                 System.err.println("✅ LSMVCTree initialized successfully");
 

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringOpContext.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringOpContext.java
@@ -53,7 +53,7 @@ public class VectorClusteringOpContext implements IIndexOperationContext, IExtra
     private final ITreeIndexFrameFactory interiorFrameFactory;
     private final ITreeIndexFrameFactory leafFrameFactory;
     private final ITreeIndexFrameFactory metadataFrameFactory;
-    private final ITreeIndexFrameFactory dataFrameFactory;
+    private ITreeIndexFrameFactory dataFrameFactory; // Mutable for LSMBTree-style frame switching
     private final IPageManager freePageManager;
     private final ITreeIndexMetadataFrame metaFrame;
     private final int vectorDimensions;
@@ -234,5 +234,19 @@ public class VectorClusteringOpContext implements IIndexOperationContext, IExtra
 
     public void setMetadataPageId(long metadataPageId) {
         this.metadataPageId = metadataPageId;
+    }
+
+    /**
+     * Sets the data frame (LSMBTree pattern for insert/delete mode switching).
+     */
+    public void setDataFrame(IVectorClusteringDataFrame dataFrame) {
+        this.dataFrame = dataFrame;
+    }
+
+    /**
+     * Sets the data frame factory (LSMBTree pattern for insert/delete mode switching).
+     */
+    public void setDataFrameFactory(ITreeIndexFrameFactory dataFrameFactory) {
+        this.dataFrameFactory = dataFrameFactory;
     }
 }

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTree.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTree.java
@@ -30,6 +30,7 @@ import org.apache.hyracks.api.exceptions.ErrorCode;
 import org.apache.hyracks.api.exceptions.HyracksDataException;
 import org.apache.hyracks.api.io.FileReference;
 import org.apache.hyracks.api.util.HyracksConstants;
+import org.apache.hyracks.data.std.primitive.LongPointable;
 import org.apache.hyracks.dataflow.common.data.accessors.ITupleReference;
 import org.apache.hyracks.dataflow.common.data.marshalling.DoubleArraySerializerDeserializer;
 import org.apache.hyracks.dataflow.common.data.marshalling.DoubleSerializerDeserializer;
@@ -38,9 +39,12 @@ import org.apache.hyracks.dataflow.common.utils.TupleUtils;
 import org.apache.hyracks.storage.am.common.api.IPageManager;
 import org.apache.hyracks.storage.am.common.api.ITreeIndexAccessor;
 import org.apache.hyracks.storage.am.common.api.ITreeIndexCursor;
+import org.apache.hyracks.storage.am.common.api.ITreeIndexFrame;
 import org.apache.hyracks.storage.am.common.api.ITreeIndexFrameFactory;
+import org.apache.hyracks.storage.am.common.api.ITreeIndexMetadataFrame;
 import org.apache.hyracks.storage.am.common.api.ITreeIndexTupleReference;
 import org.apache.hyracks.storage.am.common.frames.FrameOpSpaceStatus;
+import org.apache.hyracks.storage.am.common.freepage.MutableArrayValueReference;
 import org.apache.hyracks.storage.am.common.impls.AbstractTreeIndex;
 import org.apache.hyracks.storage.am.common.impls.TreeIndexDiskOrderScanCursor;
 import org.apache.hyracks.storage.am.common.ophelpers.IndexOperation;
@@ -82,27 +86,25 @@ public class VectorClusteringTree extends AbstractTreeIndex {
     private final int vectorDimensions;
     private final ITreeIndexFrameFactory metadataFrameFactory;
     private final ITreeIndexFrameFactory dataFrameFactory;
+    private final IVectorBinaryAccessorFactory vectorAccessorFactory;
 
     // Add missing frameTuple declaration
     private ITreeIndexTupleReference frameTuple;
-
-    private VectorClusteringTreeStaticInitializer staticInitializer;
-
+    // TODO: leave only one flag
     private boolean isStaticStructureInitialized = true;
+
+    private boolean initialized = false;
 
     public VectorClusteringTree(IBufferCache bufferCache, IPageManager freePageManager,
             ITreeIndexFrameFactory interiorFrameFactory, ITreeIndexFrameFactory leafFrameFactory,
             ITreeIndexFrameFactory metadataFrameFactory, ITreeIndexFrameFactory dataFrameFactory,
-            IBinaryComparatorFactory[] cmpFactories, int fieldCount, int vectorDimensions, FileReference file) {
+            IBinaryComparatorFactory[] cmpFactories, int fieldCount, int vectorDimensions, FileReference file,
+            org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessorFactory vectorAccessorFactory) {
         super(bufferCache, freePageManager, interiorFrameFactory, leafFrameFactory, cmpFactories, fieldCount, file);
-        //        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-        //                + "] VectorClusteringTree constructor: Started, super() call completed");
         this.vectorDimensions = vectorDimensions;
         this.metadataFrameFactory = metadataFrameFactory;
         this.dataFrameFactory = dataFrameFactory;
-        staticInitializer = null;
-        //        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-        //                + "] VectorClusteringTree constructor: Constructor completed");
+        this.vectorAccessorFactory = vectorAccessorFactory;
     }
 
     /**
@@ -201,14 +203,6 @@ public class VectorClusteringTree extends AbstractTreeIndex {
      * [additional_fields]>
      */
     private void insertVector(ITupleReference tuple, VectorClusteringOpContext ctx) throws HyracksDataException {
-        // Use unified cluster search and access pattern
-        if (!isStaticStructureInitialized()) {
-            staticInitializer = new VectorClusteringTreeStaticInitializer(this);
-            /* TODO: FOR TESTING ONLY */
-            staticInitializer.initializeThreeLevelStructure();
-            setStaticStructureInitialized();
-        }
-
         ClusterAccessResult accessResult = findClusterAndPrepareAccess(tuple, ctx, true);
 
         try {
@@ -1412,6 +1406,71 @@ public class VectorClusteringTree extends AbstractTreeIndex {
 
     public void setStaticStructureInitialized() {
         isStaticStructureInitialized = true;
+    }
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    public void setInitialized() {
+        initialized = true;
+    }
+
+
+    public void setStaticStructure(VectorClusteringTreeAccessor staticAccessor) throws HyracksDataException {
+        VectorClusteringTree staticStructure =  staticAccessor.getIndex();
+        ITreeIndexMetadataFrame metaFrame = staticAccessor.getOpContext().getMetaFrame();
+        int maxPageId = staticStructure.getPageManager().getMaxPageId(metaFrame);
+
+        // copy all pages in static structure
+
+        for (int pageId = 1; pageId <= maxPageId; pageId++) {
+            ICachedPage sourcePage = staticAccessor.getCachedPage(pageId);
+            copyPage(sourcePage);
+            staticAccessor.releasePage(sourcePage);
+        }
+
+        MutableArrayValueReference key = new MutableArrayValueReference("num_leaf_centroids".getBytes());
+        LongPointable value = LongPointable.FACTORY.createPointable();
+        metaFrame.get(key, value);
+        int numLeafCentroid = value.intValue();
+        ITreeIndexFrame directoryFrame = metadataFrameFactory.createFrame();
+
+        for (int leafCentroidId = 0; leafCentroidId < numLeafCentroid; leafCentroidId++) {
+            // For metadata pages, use freePageManager.takePage() normally
+            int metadataPageId = freePageManager.takePage(metaFrame) - 1;
+
+            ICachedPage targetPage =
+                    bufferCache.pin(BufferedFileHandle.getDiskPageId(getFileId(), metadataPageId), NEW);
+
+            directoryFrame.setPage(targetPage);
+            directoryFrame.initBuffer((byte) 0);
+
+            bufferCache.unpin(targetPage);
+
+            LOGGER.debug("Created directory page {} for leaf centroid {}", metadataPageId, leafCentroidId);
+        }
+
+        // TODO: a very hacky way
+        ICachedPage targetPage =
+                bufferCache.pin(BufferedFileHandle.getDiskPageId(getFileId(), maxPageId + numLeafCentroid + 1), NEW);
+        bufferCache.unpin(targetPage);
+
+        initialized = true;
+    }
+
+    private void copyPage(ICachedPage sourcePage) throws HyracksDataException {
+        // Copy page from source to target
+        ITreeIndexMetadataFrame metaFrame = freePageManager.createMetadataFrame();
+        int targetPageId = freePageManager.takePage(metaFrame) - 1;
+        ICachedPage targetPage =
+                bufferCache.pin(BufferedFileHandle.getDiskPageId(getFileId(), targetPageId), NEW);
+        // Copy entire page content
+        System.arraycopy(sourcePage.getBuffer().array(), 0, targetPage.getBuffer().array(), 0,
+                sourcePage.getBuffer().capacity());
+        bufferCache.unpin(targetPage);
+
+        LOGGER.debug("Copied page {} ", targetPage);
     }
 
     public void setRootPageId(int rootPageId) {

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/LSMVCTreeLocalResource.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/LSMVCTreeLocalResource.java
@@ -42,6 +42,7 @@ import org.apache.hyracks.storage.am.lsm.common.api.IVirtualBufferCache;
 import org.apache.hyracks.storage.am.lsm.common.api.IVirtualBufferCacheProvider;
 import org.apache.hyracks.storage.am.lsm.common.dataflow.LsmResource;
 import org.apache.hyracks.storage.am.lsm.vector.utils.LSMVCTreeUtils;
+import org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessorFactory;
 import org.apache.hyracks.storage.common.IIndex;
 import org.apache.hyracks.storage.common.IStorageManager;
 
@@ -56,6 +57,7 @@ public class LSMVCTreeLocalResource extends LsmResource {
     protected final int[] vectorFields;
     protected final int[] filterFields;
     protected final boolean atomic;
+    protected final IVectorBinaryAccessorFactory vectorAccessorFactory;
 
     public LSMVCTreeLocalResource(String path, IStorageManager storageManager, ITypeTraits[] typeTraits,
             IBinaryComparatorFactory[] cmpFactories, ITypeTraits[] filterTypeTraits,
@@ -65,7 +67,8 @@ public class LSMVCTreeLocalResource extends LsmResource {
             IMetadataPageManagerFactory metadataPageManagerFactory, IVirtualBufferCacheProvider vbcProvider,
             ILSMIOOperationSchedulerProvider ioSchedulerProvider, ILSMMergePolicyFactory mergePolicyFactory,
             Map<String, String> mergePolicyProperties, boolean durable, int vectorDimensions, int[] vectorFields,
-            ITypeTraits nullTypeTraits, INullIntrospector nullIntrospector, boolean atomic) {
+            ITypeTraits nullTypeTraits, INullIntrospector nullIntrospector, boolean atomic,
+            IVectorBinaryAccessorFactory vectorAccessorFactory) {
         super(path, storageManager, typeTraits, cmpFactories, filterTypeTraits, filterCmpFactories, filterFields,
                 opTrackerProvider, ioOpCallbackFactory, pageWriteCallbackFactory, metadataPageManagerFactory,
                 vbcProvider, ioSchedulerProvider, mergePolicyFactory, mergePolicyProperties, durable, nullTypeTraits,
@@ -74,15 +77,18 @@ public class LSMVCTreeLocalResource extends LsmResource {
         this.vectorFields = vectorFields;
         this.filterFields = filterFields;
         this.atomic = atomic;
+        this.vectorAccessorFactory = vectorAccessorFactory;
     }
 
     protected LSMVCTreeLocalResource(IPersistedResourceRegistry registry, JsonNode json, int vectorDimensions,
-            int[] vectorFields, int[] filterFields, boolean atomic) throws HyracksDataException {
+            int[] vectorFields, int[] filterFields, boolean atomic, IVectorBinaryAccessorFactory vectorAccessorFactory)
+            throws HyracksDataException {
         super(registry, json);
         this.vectorDimensions = vectorDimensions;
         this.vectorFields = vectorFields;
         this.filterFields = filterFields;
         this.atomic = atomic;
+        this.vectorAccessorFactory = vectorAccessorFactory;
     }
 
     @Override
@@ -93,6 +99,19 @@ public class LSMVCTreeLocalResource extends LsmResource {
         List<IVirtualBufferCache> virtualBufferCaches = vbcProvider.getVirtualBufferCaches(ncServiceCtx, fileRef);
         ioOpCallbackFactory.initialize(ncServiceCtx, this);
         pageWriteCallbackFactory.initialize(ncServiceCtx, this);
+
+        // Create vector accessor factory if not provided (e.g., when loaded from JSON)
+        IVectorBinaryAccessorFactory accessorFactory = vectorAccessorFactory;
+        if (accessorFactory == null) {
+            // Use reflection to create AOrderedListVectorBinaryAccessorFactory to avoid compile-time dependency
+            try {
+                Class<?> factoryClass = Class.forName("org.apache.asterix.dataflow.data.common.AOrderedListVectorBinaryAccessorFactory");
+                accessorFactory = (IVectorBinaryAccessorFactory) factoryClass.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new HyracksDataException("Failed to create vector accessor factory", e);
+            }
+        }
+
         return LSMVCTreeUtils.createLSMTree(storageConfig, ioManager, virtualBufferCaches, fileRef,
                 storageManager.getBufferCache(ncServiceCtx), typeTraits, cmpFactories, 0.01, // bloomFilterFalsePositiveRate
                 mergePolicyFactory.createMergePolicy(mergePolicyProperties, ncServiceCtx),
@@ -101,7 +120,7 @@ public class LSMVCTreeLocalResource extends LsmResource {
                 vectorDimensions, vectorFields, filterFields, null, // filterFrameFactory
                 null, // filterManager
                 null, // filterHelper
-                durable, metadataPageManagerFactory, atomic, null);
+                durable, metadataPageManagerFactory, atomic, null, accessorFactory);
     }
 
     @Override
@@ -127,6 +146,6 @@ public class LSMVCTreeLocalResource extends LsmResource {
         //        int[] vectorFields = OBJECT_MAPPER.convertValue(json.get("vectorFields"), int[].class);
         //        int[] filterFields = OBJECT_MAPPER.convertValue(json.get("filterFields"), int[].class);
         //        boolean atomic = json.get("atomic").asBoolean();
-        return new LSMVCTreeLocalResource(registry, json, 784, null, null, false);
+        return new LSMVCTreeLocalResource(registry, json, 784, null, null, false, null);
     }
 }

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/LSMVCTreeLocalResourceFactory.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/LSMVCTreeLocalResourceFactory.java
@@ -32,6 +32,7 @@ import org.apache.hyracks.storage.am.lsm.common.api.ILSMOperationTrackerFactory;
 import org.apache.hyracks.storage.am.lsm.common.api.ILSMPageWriteCallbackFactory;
 import org.apache.hyracks.storage.am.lsm.common.api.IVirtualBufferCacheProvider;
 import org.apache.hyracks.storage.am.lsm.common.dataflow.LsmResourceFactory;
+import org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessorFactory;
 import org.apache.hyracks.storage.common.IResource;
 import org.apache.hyracks.storage.common.IStorageManager;
 
@@ -42,6 +43,7 @@ public class LSMVCTreeLocalResourceFactory extends LsmResourceFactory {
     protected final int vectorDimensions;
     protected final int[] vectorFields;
     protected final boolean atomic;
+    protected final IVectorBinaryAccessorFactory vectorAccessorFactory;
 
     public LSMVCTreeLocalResourceFactory(IStorageManager storageManager, ITypeTraits[] typeTraits,
             IBinaryComparatorFactory[] cmpFactories, ITypeTraits[] filterTypeTraits,
@@ -51,7 +53,8 @@ public class LSMVCTreeLocalResourceFactory extends LsmResourceFactory {
             IMetadataPageManagerFactory metadataPageManagerFactory, IVirtualBufferCacheProvider vbcProvider,
             ILSMIOOperationSchedulerProvider ioSchedulerProvider, ILSMMergePolicyFactory mergePolicyFactory,
             Map<String, String> mergePolicyProperties, boolean durable, int vectorDimensions, int[] vectorFields,
-            ITypeTraits nullTypeTraits, INullIntrospector nullIntrospector, boolean atomic) {
+            ITypeTraits nullTypeTraits, INullIntrospector nullIntrospector, boolean atomic,
+            IVectorBinaryAccessorFactory vectorAccessorFactory) {
         super(storageManager, typeTraits, cmpFactories, filterTypeTraits, filterCmpFactories, filterFields,
                 opTrackerFactory, ioOpCallbackFactory, pageWriteCallbackFactory, metadataPageManagerFactory,
                 vbcProvider, ioSchedulerProvider, mergePolicyFactory, mergePolicyProperties, durable, nullTypeTraits,
@@ -59,6 +62,7 @@ public class LSMVCTreeLocalResourceFactory extends LsmResourceFactory {
         this.vectorDimensions = vectorDimensions;
         this.vectorFields = vectorFields;
         this.atomic = atomic;
+        this.vectorAccessorFactory = vectorAccessorFactory;
     }
 
     @Override
@@ -67,6 +71,6 @@ public class LSMVCTreeLocalResourceFactory extends LsmResourceFactory {
                 filterTypeTraits, filterCmpFactories, filterFields, opTrackerProvider, ioOpCallbackFactory,
                 pageWriteCallbackFactory, metadataPageManagerFactory, vbcProvider, ioSchedulerProvider,
                 mergePolicyFactory, mergePolicyProperties, durable, vectorDimensions, vectorFields, nullTypeTraits,
-                nullIntrospector, atomic);
+                nullIntrospector, atomic, vectorAccessorFactory);
     }
 }

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTree.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTree.java
@@ -19,6 +19,7 @@
 
 package org.apache.hyracks.storage.am.lsm.vector.impls;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -63,15 +64,18 @@ import org.apache.hyracks.storage.am.lsm.common.impls.LSMIndexDiskComponentBulkL
 import org.apache.hyracks.storage.am.lsm.common.impls.LSMTreeIndexAccessor.ICursorFactory;
 import org.apache.hyracks.storage.am.lsm.common.impls.LSMVCTreeComponentFileReferences;
 import org.apache.hyracks.storage.am.lsm.common.impls.LoadOperation;
+import org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessorFactory;
 import org.apache.hyracks.storage.am.vector.impls.VectorClusteringTree;
 import org.apache.hyracks.storage.common.IIndexAccessParameters;
 import org.apache.hyracks.storage.common.IIndexAccessor;
 import org.apache.hyracks.storage.common.IIndexBulkLoader;
 import org.apache.hyracks.storage.common.IIndexCursor;
+import org.apache.hyracks.storage.common.IIndexCursorStats;
 import org.apache.hyracks.storage.common.ISearchPredicate;
-import org.apache.hyracks.storage.common.MultiComparator;
+import org.apache.hyracks.storage.common.NoOpIndexCursorStats;
 import org.apache.hyracks.storage.common.buffercache.IBufferCache;
 import org.apache.hyracks.storage.common.buffercache.ICachedPage;
+import org.apache.hyracks.storage.common.buffercache.IPageWriteCallback;
 import org.apache.hyracks.util.trace.ITracer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -92,73 +96,59 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
     protected final ITreeIndexFrameFactory interiorFrameFactory;
     protected final ITreeIndexFrameFactory leafFrameFactory;
     protected final ITreeIndexFrameFactory metadataFrameFactory;
-    protected final ITreeIndexFrameFactory dataFrameFactory;
+    protected final ITreeIndexFrameFactory insertDataFrameFactory;
+    protected final ITreeIndexFrameFactory deleteDataFrameFactory;
 
     // Vector clustering specific parameters
     protected final IBinaryComparatorFactory[] cmpFactories;
     protected final int vectorDimensions;
     protected final boolean needKeyDupCheck;
+    protected final IVectorBinaryAccessorFactory vectorAccessorFactory;
 
     protected LSMVCTreeDiskComponent staticStructure;
 
     public LSMVCTree(NCConfig storageConfig, IIOManager ioManager, List<IVirtualBufferCache> virtualBufferCaches,
             ITreeIndexFrameFactory interiorFrameFactory, ITreeIndexFrameFactory leafFrameFactory,
-            ITreeIndexFrameFactory metadataFrameFactory, ITreeIndexFrameFactory dataFrameFactory,
-            IBufferCache diskBufferCache, ILSMIndexFileManager fileManager, ILSMDiskComponentFactory componentFactory,
+            ITreeIndexFrameFactory metadataFrameFactory, ITreeIndexFrameFactory insertDataFrameFactory,
+            ITreeIndexFrameFactory deleteDataFrameFactory, IBufferCache diskBufferCache,
+            ILSMIndexFileManager fileManager, ILSMDiskComponentFactory componentFactory,
             ILSMDiskComponentFactory bulkLoadComponentFactory, IComponentFilterHelper filterHelper,
             ILSMComponentFilterFrameFactory filterFrameFactory, LSMComponentFilterManager filterManager,
             double bloomFilterFalsePositiveRate, IBinaryComparatorFactory[] cmpFactories, ILSMMergePolicy mergePolicy,
             ILSMOperationTracker opTracker, ILSMIOOperationScheduler ioScheduler,
             ILSMIOOperationCallbackFactory ioOpCallbackFactory, ILSMPageWriteCallbackFactory pageWriteCallbackFactory,
             boolean needKeyDupCheck, int vectorDimensions, int[] vectorFields, int[] filterFields, boolean durable,
-            boolean atomic) throws HyracksDataException {
+            boolean atomic, org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessorFactory vectorAccessorFactory)
+            throws HyracksDataException {
 
         super(storageConfig, ioManager, virtualBufferCaches, diskBufferCache, fileManager, bloomFilterFalsePositiveRate,
                 mergePolicy, opTracker, ioScheduler, ioOpCallbackFactory, pageWriteCallbackFactory, componentFactory,
                 bulkLoadComponentFactory, filterFrameFactory, filterManager, filterFields, durable, filterHelper,
                 vectorFields, ITracer.NONE, atomic);
-        //        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-        //                + "] LSMVCTree constructor: Started, super() call completed");
-
         this.interiorFrameFactory = interiorFrameFactory;
         this.leafFrameFactory = leafFrameFactory;
         this.metadataFrameFactory = metadataFrameFactory;
-        this.dataFrameFactory = dataFrameFactory;
+        this.insertDataFrameFactory = insertDataFrameFactory;
+        this.deleteDataFrameFactory = deleteDataFrameFactory;
         this.cmpFactories = cmpFactories;
         this.vectorDimensions = vectorDimensions;
         this.needKeyDupCheck = needKeyDupCheck;
+        this.vectorAccessorFactory = vectorAccessorFactory;
 
-        // Create in-memory components using VectorClusteringTree
-        //        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-        //                + "] LSMVCTree constructor: About to create memory components, count=" + virtualBufferCaches.size());
         int i = 0;
         for (IVirtualBufferCache virtualBufferCache : virtualBufferCaches) {
-            //            System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-            //                    + "] LSMVCTree constructor: Memory component loop iteration " + i);
-            //            System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-            //                    + "] LSMVCTree constructor: About to create VectorClusteringTree");
             String baseDirPath = fileManager.getBaseDir() + "_virtual_" + i;
-            //            System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-            //                    + "] LSMVCTree constructor: About to resolve path: " + baseDirPath);
             FileReference virtualFileRef = ioManager.resolve(baseDirPath);
-            //            System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-            //                    + "] LSMVCTree constructor: Path resolved successfully");
+            // Memory components use insertDataFrameFactory for normal inserts
             VectorClusteringTree vcTree = new VectorClusteringTree(virtualBufferCache,
                     new VirtualFreePageManager(virtualBufferCache), interiorFrameFactory, leafFrameFactory,
-                    metadataFrameFactory, dataFrameFactory, cmpFactories, 1, vectorDimensions, virtualFileRef);
-            //            System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-            //                    + "] LSMVCTree constructor: VectorClusteringTree created");
+                    metadataFrameFactory, insertDataFrameFactory, cmpFactories, 1, vectorDimensions, virtualFileRef,
+                    vectorAccessorFactory);
             LSMVCTreeMemoryComponent mutableComponent = new LSMVCTreeMemoryComponent(this, vcTree, virtualBufferCache,
                     filterHelper == null ? null : filterHelper.createFilter());
-            //            System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-            //                    + "] LSMVCTree constructor: LSMVCTreeMemoryComponent created");
             memoryComponents.add(mutableComponent);
-            //            System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-            //                    + "] LSMVCTree constructor: Memory component added to list");
             ++i;
         }
-        //        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-        //                + "] LSMVCTree constructor: All memory components created, constructor completed");
     }
 
     public void setStaticStructure(LSMVCTreeDiskComponent staticStructure) {
@@ -263,6 +253,11 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
     @Override
     public void modify(IIndexOperationContext ictx, ITupleReference tuple) throws HyracksDataException {
         LSMVCTreeOpContext ctx = (LSMVCTreeOpContext) ictx;
+
+        // Debug logging
+        System.err.println("[LSMVCTree.modify] Operation: " + ctx.getOperation() +
+                          ", Thread: " + Thread.currentThread().getId());
+
         ITupleReference indexTuple;
         if (ctx.getIndexTuple() != null) {
             ctx.getIndexTuple().reset(tuple);
@@ -273,12 +268,19 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
 
         switch (ctx.getOperation()) {
             case PHYSICALDELETE:
+                System.err.println("[LSMVCTree.modify] Executing PHYSICALDELETE");
                 ctx.getCurrentMutableVCTreeAccessor().delete(indexTuple);
                 break;
             case INSERT:
+                System.err.println("[LSMVCTree.modify] Executing INSERT");
                 insert(indexTuple, ctx);
                 break;
+            case DELETE:
+                System.err.println("[LSMVCTree.modify] Executing DELETE");
+                delete(indexTuple, ctx);
+                break;
             default:
+                System.err.println("[LSMVCTree.modify] Executing default (UPSERT)");
                 ctx.getCurrentMutableVCTreeAccessor().upsert(indexTuple);
                 break;
         }
@@ -286,9 +288,53 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
     }
 
     private boolean insert(ITupleReference tuple, LSMVCTreeOpContext ctx) throws HyracksDataException {
-        // For now, implement basic insert without duplicate checking
         // TODO: Implement vector-specific duplicate checking logic
-        ctx.getCurrentMutableVCTreeAccessor().insert(tuple);
+        VectorClusteringTree.VectorClusteringTreeAccessor memoryComponentAccessor =
+                (VectorClusteringTree.VectorClusteringTreeAccessor) (ctx.getCurrentMutableVCTreeAccessor());
+        VectorClusteringTree.VectorClusteringTreeAccessor staticAccessor =
+                (VectorClusteringTree.VectorClusteringTreeAccessor) getStaticStructure().getIndex().createAccessor(NoOpIndexAccessParameters.INSTANCE);
+
+        if (!memoryComponentAccessor.getIndex().isInitialized()) {
+            memoryComponentAccessor.getIndex().setStaticStructure(staticAccessor);
+        }
+
+        memoryComponentAccessor.insert(tuple);
+
+        return true;
+    }
+
+    /**
+     * Handles delete operation for vector index.
+     *
+     * Delete flow:
+     * 1. Call delete() on VectorClusteringTreeAccessor with the original input tuple
+     * 2. VectorClusteringTreeAccessor.delete() sets operation to DELETE and calls insertVector()
+     * 3. insertVector() navigates, calculates distance, and constructs data tuple
+     * 4. Based on operation type (DELETE), creates antimatter tuple with bit 7 set
+     * 5. Antimatter tuple is inserted into data pages
+     *
+     * This approach reuses all existing insertVector() logic and only differs in
+     * the antimatter bit being set when the operation type is DELETE.
+     */
+    private boolean delete(ITupleReference tuple, LSMVCTreeOpContext ctx) throws HyracksDataException {
+        // Get the current mutable VectorClusteringTree accessor
+        VectorClusteringTree.VectorClusteringTreeAccessor memoryComponentAccessor = (ctx.getCurrentMutableVCTreeAccessor());
+        VectorClusteringTree.VectorClusteringTreeAccessor staticAccessor =
+                (VectorClusteringTree.VectorClusteringTreeAccessor) getStaticStructure().getIndex()
+                        .createAccessor(NoOpIndexAccessParameters.INSTANCE);
+
+        // Ensure static structure is initialized (same pattern as insert)
+        if (!memoryComponentAccessor.getIndex().isInitialized()) {
+            memoryComponentAccessor.getIndex().setStaticStructure(staticAccessor);
+        }
+
+        System.err.println("[LSMVCTree.delete] Calling VectorClusteringTreeAccessor.delete(), Thread="
+                + Thread.currentThread().getId());
+
+        // Call delete() which will set operation to DELETE and delegate to insertVector()
+        // insertVector() will create an antimatter tuple based on the DELETE operation
+        memoryComponentAccessor.delete(tuple);
+
         return true;
     }
 
@@ -314,7 +360,7 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
         IIndexAccessor accessor = flushingComponent.getIndex().createAccessor(NoOpIndexAccessParameters.INSTANCE);
 
         ILSMDiskComponent component = null;
-        LSMVCTreeDiskComponentLoader componentFlushLoader;
+        LSMVCTreeDiskComponentLoader componentFlushLoader = null;
         try {
             component = createDiskComponent(componentFactory, flushOp.getTarget(), null, null, true);
 
@@ -322,28 +368,27 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
                     (LSMVCTreeDiskComponentLoader) ((LSMVCTreeDiskComponent) component).createFlushLoader(storageConfig,
                             operation, false, pageWriteCallbackFactory.createPageWriteCallback());
 
-            try {
-                VectorClusteringTree.VectorClusteringTreeAccessor vcTreeAccessor =
-                        (VectorClusteringTree.VectorClusteringTreeAccessor) accessor;
-                ITreeIndexMetadataFrame componentMetaFrame = (vcTreeAccessor).getOpContext().getMetaFrame();
-                // Simple bulk load - just copy all pages
-                int maxPageId = flushingComponent.getIndex().getPageManager().getMaxPageId(componentMetaFrame);
-
-                for (int pageId = 0; pageId <= maxPageId; pageId++) {
-                    ICachedPage sourcePage = vcTreeAccessor.getCachedPage(pageId);
-                    componentFlushLoader.copyPage(sourcePage);
-                    vcTreeAccessor.releasePage(sourcePage);
-                }
-
-                componentFlushLoader.end();
-
-            } catch (Throwable e) {
-                componentFlushLoader.abort();
-                throw e;
+            VectorClusteringTree.VectorClusteringTreeAccessor vcTreeAccessor =
+                    (VectorClusteringTree.VectorClusteringTreeAccessor) accessor;
+            ITreeIndexMetadataFrame componentMetaFrame = (vcTreeAccessor).getOpContext().getMetaFrame();
+            // Simple bulk load - just copy all pages
+            int maxPageId = flushingComponent.getIndex().getPageManager().getMaxPageId(componentMetaFrame);
+            System.err.println();
+            for (int pageId = 0; pageId <= maxPageId; pageId++) {
+                ICachedPage sourcePage = vcTreeAccessor.getCachedPage(pageId);
+                componentFlushLoader.copyPage(sourcePage);
+                vcTreeAccessor.releasePage(sourcePage);
             }
+
+            componentFlushLoader.end();
+
         } catch (Throwable e) {
-            if (component != null) {
-                component.destroy();
+            try {
+                if (componentFlushLoader != null) {
+                    componentFlushLoader.abort();
+                }
+            } catch (Throwable th) {
+                e.addSuppressed(th);
             }
             throw e;
         }
@@ -353,66 +398,74 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
     @Override
     public ILSMDiskComponent doMerge(ILSMIOOperation operation) throws HyracksDataException {
         LSMVCTreeMergeOperation mergeOp = (LSMVCTreeMergeOperation) operation;
+        IIndexCursor cursor = mergeOp.getCursor();
+        ILSMDiskComponent mergedComponent;
+        ILSMDiskComponentBulkLoader componentBulkLoader = null;
 
-        // Create the new merged disk component
-        ILSMDiskComponent component = null;
         try {
-            component = createDiskComponent(componentFactory, mergeOp.getTarget(), null, null, true);
-
-            // Create a bulk loader for the merged disk component
-            ILSMDiskComponentBulkLoader componentBulkLoader = component.createBulkLoader(storageConfig, operation, 1.0f,
-                    false, 0L, false, false, false, pageWriteCallbackFactory.createPageWriteCallback());
-
             try {
-                // Get the components to be merged
-                LSMVCTreeOpContext opCtx = (LSMVCTreeOpContext) mergeOp.getAccessor().getOpContext();
-                List<ILSMComponent> componentsToMerge = opCtx.getComponentHolder();
+                RangePredicate rangePred = new RangePredicate(null, null, true, true, null, null);
 
-                // Use a cursor to scan all components being merged
-                LSMVCTreeSearchCursor cursor = new LSMVCTreeSearchCursor(opCtx);
-                RangePredicate pred = new RangePredicate(null, null, true, true, null, null);
+                // Search all merging components (cursor already configured for full-scan mode)
+                search(mergeOp.getAccessor().getOpContext(), cursor, rangePred);
 
-                // Create initial state for cursor spanning all components to merge
-                LSMVCTreeCursorInitialState initialState = new LSMVCTreeCursorInitialState(interiorFrameFactory,
-                        leafFrameFactory, metadataFrameFactory, dataFrameFactory, MultiComparator.create(cmpFactories),
-                        getHarness(), pred, opCtx.getSearchOperationCallback(), componentsToMerge);
-
-                // Merge all components
-                cursor.open(initialState, pred);
                 try {
+                    // Create merged disk component
+                    List<ILSMComponent> mergedComponents = mergeOp.getMergingComponents();
+                    long numElements = getNumberOfElements(mergedComponents);
+                    mergedComponent = createDiskComponent(componentFactory, mergeOp.getTarget(), null, null, true);
+
+                    // Set parameters for merge operation (including static structure reference)
+                    Map<String, Object> parameters = new HashMap<>();
+                    parameters.put("static_structure_component", getStaticStructure());
+                    mergeOp.getAccessor().getOpContext().setParameters(parameters);
+
+                    // Create bulk loader (delegates to VCTreeBulkLoader)
+                    IPageWriteCallback pageWriteCallback = pageWriteCallbackFactory.createPageWriteCallback();
+                    componentBulkLoader = mergedComponent.createBulkLoader(storageConfig, operation, 1.0f, false,
+                            numElements, false, false, false, pageWriteCallback);
+
+                    // Iterate cursor and add tuples
+                    // Cursor delivers tuples cluster-by-cluster, already reconciled
                     while (cursor.hasNext()) {
                         cursor.next();
-                        ITupleReference tuple = cursor.getTuple();
-                        componentBulkLoader.add(tuple);
+                        ITupleReference frameTuple = cursor.getTuple();
+                        componentBulkLoader.add(frameTuple);
                     }
                 } finally {
                     cursor.close();
                 }
-
-                componentBulkLoader.end();
-            } catch (Throwable e) {
-                try {
-                    if (componentBulkLoader != null) {
-                        componentBulkLoader.abort();
-                    }
-                } catch (Throwable th) {
-                    e.addSuppressed(th);
-                }
-                throw e;
+            } finally {
+                cursor.destroy();
             }
-        } catch (Throwable e) {
+
+            componentBulkLoader.end();
+        } catch (Throwable e) { // NOSONAR.. As per the contract, we should either abort or end
             try {
-                if (component != null) {
-                    component.markAsValid(false, null);
-                    component.destroy();
-                    component = null;
+                if (componentBulkLoader != null) {
+                    componentBulkLoader.abort();
                 }
-            } catch (Throwable th) {
+            } catch (Throwable th) { // NOSONAR Don't lose the root failure
                 e.addSuppressed(th);
             }
             throw e;
         }
-        return component;
+
+        return mergedComponent;
+    }
+
+    /**
+     * Get number of elements in merging components.
+     * Used to estimate bulk loader size.
+     */
+    private long getNumberOfElements(List<ILSMComponent> mergedComponents) throws HyracksDataException {
+        long numElements = 0L;
+        for (ILSMComponent comp : mergedComponents) {
+            LSMVCTreeDiskComponent diskComp = (LSMVCTreeDiskComponent) comp;
+            // Get component size if available, otherwise use default estimate
+            numElements += diskComp.getComponentSize();
+        }
+        return numElements;
     }
 
     @Override
@@ -424,7 +477,7 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
 
     @Override
     public LSMVCTreeOpContext createOpContext(IIndexAccessParameters iap) {
-        return new LSMVCTreeOpContext(this, getTreeFields(), getFilterFields(), getFilterCmpFactories(),
+        return new LSMVCTreeOpContext(this, memoryComponents, getTreeFields(), getFilterFields(), getFilterCmpFactories(),
                 (IExtendedModificationOperationCallback) iap.getModificationCallback(),
                 iap.getSearchOperationCallback(), tracer, iap);
     }
@@ -449,8 +502,16 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
         return metadataFrameFactory;
     }
 
-    public ITreeIndexFrameFactory getDataFrameFactory() {
-        return dataFrameFactory;
+    public ITreeIndexFrameFactory getInsertDataFrameFactory() {
+        return insertDataFrameFactory;
+    }
+
+    public ITreeIndexFrameFactory getDeleteDataFrameFactory() {
+        return deleteDataFrameFactory;
+    }
+
+    public IBinaryComparatorFactory[] getCmpFactories() {
+        return cmpFactories;
     }
 
     @Override
@@ -491,16 +552,46 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
     @Override
     protected LSMComponentFileReferences getMergeFileReferences(ILSMDiskComponent firstComponent,
             ILSMDiskComponent lastComponent) throws HyracksDataException {
-        return fileManager.getRelMergeFileReference(firstComponent.getId().toString(),
-                lastComponent.getId().toString());
+        // Extract file names from components (e.g., "0_0" from file "0_0_vct")
+        LSMVCTreeDiskComponent first = (LSMVCTreeDiskComponent) firstComponent;
+        LSMVCTreeDiskComponent last = (LSMVCTreeDiskComponent) lastComponent;
+
+        String firstName = first.getIndex().getFileReference().getFile().getName();
+        String lastName = last.getIndex().getFileReference().getFile().getName();
+
+        return fileManager.getRelMergeFileReference(firstName, lastName);
     }
 
     @Override
     protected ILSMIOOperation createMergeOperation(AbstractLSMIndexOperationContext opCtx,
             LSMComponentFileReferences mergeFileRefs, ILSMIOOperationCallback callback) throws HyracksDataException {
-        IIndexCursor cursor = createAccessor(opCtx).createSearchCursor(false);
-        return new LSMVCTreeMergeOperation(createAccessor(opCtx), cursor, null,
-                mergeFileRefs.getInsertIndexFileReference(), callback, getIndexIdentifier());
+
+        // Determine if deleted tuples should be preserved
+        List<ILSMComponent> mergingComponents = opCtx.getComponentHolder();
+        boolean returnDeletedTuples = true;
+
+        // If merging oldest component, anti-matter tuples can be discarded
+        // Check if the last component in mergingComponents is the oldest disk component
+        if (!diskComponents.isEmpty() && mergingComponents.size() > 0) {
+            ILSMComponent lastMergingComponent = mergingComponents.get(mergingComponents.size() - 1);
+            ILSMComponent oldestDiskComponent = diskComponents.get(diskComponents.size() - 1);
+
+            if (lastMergingComponent == oldestDiskComponent) {
+                returnDeletedTuples = false; // Anti-matter can be discarded
+            }
+        }
+
+        // Create cursor with full-scan mode enabled for merge
+        IIndexCursorStats stats = NoOpIndexCursorStats.INSTANCE;
+        ILSMIndexAccessor accessor = createAccessor(opCtx);
+
+        // Create LSMVCTreeSearchCursor with fullScanMode=true for merge
+        boolean fullScanMode = true; // Merge requires sequential cluster iteration
+        IIndexCursor cursor = new LSMVCTreeSearchCursor((ILSMIndexOperationContext) opCtx, returnDeletedTuples,
+                fullScanMode, stats);
+
+        return new LSMVCTreeMergeOperation(accessor, cursor, stats, mergeFileRefs.getInsertIndexFileReference(),
+                callback, getIndexIdentifier());
     }
 
     protected ICursorFactory getCursorFactory() {

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeOpContext.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeOpContext.java
@@ -19,15 +19,28 @@
 
 package org.apache.hyracks.storage.am.lsm.vector.impls;
 
+import java.util.List;
+
+import org.apache.hyracks.api.dataflow.value.IBinaryComparator;
 import org.apache.hyracks.api.dataflow.value.IBinaryComparatorFactory;
 import org.apache.hyracks.api.exceptions.HyracksDataException;
+import org.apache.hyracks.api.util.CleanupUtils;
+import org.apache.hyracks.data.std.accessors.DoubleBinaryComparatorFactory;
+import org.apache.hyracks.data.std.accessors.LongBinaryComparatorFactory;
 import org.apache.hyracks.storage.am.common.api.IExtendedModificationOperationCallback;
-import org.apache.hyracks.storage.am.common.api.ITreeIndexAccessor;
+import org.apache.hyracks.storage.am.common.api.ITreeIndexFrameFactory;
+import org.apache.hyracks.storage.am.common.impls.IndexAccessParameters;
+import org.apache.hyracks.storage.am.common.impls.NoOpOperationCallback;
 import org.apache.hyracks.storage.am.common.ophelpers.IndexOperation;
+import org.apache.hyracks.storage.am.lsm.common.api.ILSMMemoryComponent;
 import org.apache.hyracks.storage.am.lsm.common.impls.AbstractLSMIndexOperationContext;
+import org.apache.hyracks.storage.am.vector.api.IVectorClusteringDataFrame;
+import org.apache.hyracks.storage.am.vector.impls.VectorClusteringOpContext;
+import org.apache.hyracks.storage.am.vector.impls.VectorClusteringTree;
 import org.apache.hyracks.storage.common.IIndexAccessParameters;
 import org.apache.hyracks.storage.common.ISearchOperationCallback;
 import org.apache.hyracks.storage.common.ISearchPredicate;
+import org.apache.hyracks.storage.common.MultiComparator;
 import org.apache.hyracks.util.trace.ITracer;
 
 /**
@@ -38,81 +51,137 @@ import org.apache.hyracks.util.trace.ITracer;
  */
 public class LSMVCTreeOpContext extends AbstractLSMIndexOperationContext {
 
-    private LSMVCTreeCursorInitialState searchInitialState;
-    private ISearchPredicate searchPredicate;
-    private int currentMutableComponentId = 0;
+    /*
+     * Finals - pre-created resources (LSMBTree pattern)
+     */
+    private final ITreeIndexFrameFactory insertDataFrameFactory;
+    private final ITreeIndexFrameFactory deleteDataFrameFactory;
+    private final IVectorClusteringDataFrame insertDataFrame;
+    private final IVectorClusteringDataFrame deleteDataFrame;
+    private final VectorClusteringTree[] mutableVCTrees;
+    private final VectorClusteringTree.VectorClusteringTreeAccessor[] mutableVCTreeAccessors;
+    private final VectorClusteringOpContext[] mutableVCTreeOpCtxs;
+    private final MultiComparator cmp;
+    private final LSMVCTreeCursorInitialState searchInitialState;
     private final IIndexAccessParameters iap;
 
-    public LSMVCTreeOpContext(LSMVCTree lsmTree, int[] treeFields, int[] filterFields,
-            IBinaryComparatorFactory[] filterCmpFactories, IExtendedModificationOperationCallback modificationCallback,
-            ISearchOperationCallback searchCallback, ITracer tracer, IIndexAccessParameters iap) {
+    /*
+     * Mutables - switched per operation
+     */
+    private VectorClusteringTree.VectorClusteringTreeAccessor currentMutableVCTreeAccessor;
+    private VectorClusteringOpContext currentMutableVCTreeOpCtx;
+    private boolean destroyed = false;
+
+    public LSMVCTreeOpContext(LSMVCTree lsmTree, List<ILSMMemoryComponent> mutableComponents,
+            int[] treeFields, int[] filterFields, IBinaryComparatorFactory[] filterCmpFactories,
+            IExtendedModificationOperationCallback modificationCallback, ISearchOperationCallback searchCallback,
+            ITracer tracer, IIndexAccessParameters iap) {
         super(lsmTree, treeFields, filterFields, filterCmpFactories, searchCallback, modificationCallback, tracer);
+
         this.iap = iap;
+        this.insertDataFrameFactory = lsmTree.getInsertDataFrameFactory();
+        this.deleteDataFrameFactory = lsmTree.getDeleteDataFrameFactory();
+
+        // Create MultiComparator using ADM-aware comparators from LSMVCTree
+        // These comparators handle the 1-byte type tag prefix for ADM-tagged types (ADOUBLE, AINT32, etc.)
+        IBinaryComparatorFactory[] cmpFactories = lsmTree.getCmpFactories();
+        IBinaryComparator[] comparators = new IBinaryComparator[cmpFactories.length];
+        for (int i = 0; i < comparators.length; i++) {
+            comparators[i] = cmpFactories[i].createBinaryComparator();
+        }
+        this.cmp = new MultiComparator(comparators);
+
+        // Pre-create data frames for insert and delete operations (LSMBTree pattern)
+        this.insertDataFrame = (IVectorClusteringDataFrame) insertDataFrameFactory.createFrame();
+        this.deleteDataFrame = (IVectorClusteringDataFrame) deleteDataFrameFactory.createFrame();
+
+        // Pre-create accessors and op contexts for ALL mutable components (LSMBTree pattern)
+        mutableVCTrees = new VectorClusteringTree[mutableComponents.size()];
+        mutableVCTreeAccessors = new VectorClusteringTree.VectorClusteringTreeAccessor[mutableComponents.size()];
+        mutableVCTreeOpCtxs = new VectorClusteringOpContext[mutableComponents.size()];
+
+        for (int i = 0; i < mutableComponents.size(); i++) {
+            LSMVCTreeMemoryComponent mutableComponent = (LSMVCTreeMemoryComponent) mutableComponents.get(i);
+            mutableVCTrees[i] = mutableComponent.getIndex();
+            IIndexAccessParameters componentIap =
+                    new IndexAccessParameters(modificationCallback, NoOpOperationCallback.INSTANCE);
+            mutableVCTreeAccessors[i] = (VectorClusteringTree.VectorClusteringTreeAccessor) mutableVCTrees[i].createAccessor(componentIap);
+            mutableVCTreeOpCtxs[i] = mutableVCTreeAccessors[i].getOpContext();
+        }
+
+        // Initialize search state with insertDataFrameFactory (default mode)
         this.searchInitialState = new LSMVCTreeCursorInitialState(lsmTree.getInteriorFrameFactory(),
-                lsmTree.getLeafFrameFactory(), lsmTree.getMetadataFrameFactory(), lsmTree.getDataFrameFactory(), null,
+                lsmTree.getLeafFrameFactory(), lsmTree.getMetadataFrameFactory(), insertDataFrameFactory, cmp,
                 lsmTree.getHarness(), null, searchCallback, componentHolder);
     }
 
     @Override
-    public void setOperation(IndexOperation newOp) throws HyracksDataException {
-        super.setOperation(newOp);
+    public void setOperation(IndexOperation newOp) {
+        reset();
+        this.op = newOp;
     }
 
-    @Override
-    public void reset() {
-        super.reset();
+    public void setInsertMode() {
+        currentMutableVCTreeOpCtx.setDataFrame(insertDataFrame);
+        currentMutableVCTreeOpCtx.setDataFrameFactory(insertDataFrameFactory);
     }
 
-    @Override
-    public void destroy() throws HyracksDataException {
-        // No additional cleanup needed beyond the base class
+    public void setDeleteMode() {
+        currentMutableVCTreeOpCtx.setDataFrame(deleteDataFrame);
+        currentMutableVCTreeOpCtx.setDataFrameFactory(deleteDataFrameFactory);
     }
 
     @Override
     public void setCurrentMutableComponentId(int currentMutableComponentId) {
-        this.currentMutableComponentId = currentMutableComponentId;
+        setCurrentMutableVCTreeAccessor(mutableVCTreeAccessors[currentMutableComponentId]);
+        currentMutableVCTreeOpCtx = mutableVCTreeOpCtxs[currentMutableComponentId];
+        switch (op) {
+            case SEARCH:
+            case DISKORDERSCAN:
+            case UPDATE:
+                // Keep leafFrame as is for UPDATE (preserve previous operation semantics)
+                break;
+            case UPSERT:
+            case INSERT:
+                setInsertMode();
+                break;
+            case PHYSICALDELETE:
+            case DELETE:
+                setDeleteMode();
+                break;
+        }
     }
 
-    public int getCurrentMutableComponentId() {
-        return currentMutableComponentId;
+    public VectorClusteringTree.VectorClusteringTreeAccessor getCurrentMutableVCTreeAccessor() {
+        return currentMutableVCTreeAccessor;
     }
 
-    /**
-     * Gets the search initial state.
-     */
+    public void setCurrentMutableVCTreeAccessor(VectorClusteringTree.VectorClusteringTreeAccessor accessor) {
+        this.currentMutableVCTreeAccessor = accessor;
+    }
+
     public LSMVCTreeCursorInitialState getSearchInitialState() {
         return searchInitialState;
     }
 
-    /**
-     * Gets the search predicate.
-     */
-    @Override
-    public ISearchPredicate getSearchPredicate() {
-        return searchPredicate;
+    public MultiComparator getCmp() {
+        return cmp;
     }
 
-    /**
-     * Sets the search predicate.
-     */
-    @Override
-    public void setSearchPredicate(ISearchPredicate searchPredicate) {
-        this.searchPredicate = searchPredicate;
-    }
-
-    /**
-     * Gets the index access parameters.
-     */
     public IIndexAccessParameters getIndexAccessParameters() {
         return iap;
     }
 
-    /**
-     * Gets the accessor for the current mutable VectorClusteringTree component.
-     */
-    public ITreeIndexAccessor getCurrentMutableVCTreeAccessor() throws HyracksDataException {
-        LSMVCTree lsmVCTree = (LSMVCTree) getIndex();
-        LSMVCTreeMemoryComponent memComponent = (LSMVCTreeMemoryComponent) lsmVCTree.getCurrentMemoryComponent();
-        return memComponent.getIndex().createAccessor(iap);
+    @Override
+    public void destroy() throws HyracksDataException {
+        if (destroyed) {
+            return;
+        }
+        destroyed = true;
+        Throwable failure = CleanupUtils.destroy(null, mutableVCTreeAccessors);
+        failure = CleanupUtils.destroy(failure, mutableVCTreeOpCtxs);
+        if (failure != null) {
+            throw HyracksDataException.create(failure);
+        }
     }
 }

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeSearchCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeSearchCursor.java
@@ -19,6 +19,7 @@
 
 package org.apache.hyracks.storage.am.lsm.vector.impls;
 
+import java.util.Arrays;
 import java.util.PriorityQueue;
 
 import org.apache.hyracks.api.exceptions.HyracksDataException;
@@ -64,9 +65,8 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
     // Store search predicate for component switching
     private ISearchPredicate searchPredicate;
 
-    // Track K (target limit) and reconciled output count for cluster advancement decisions
+    // Track K (target limit) for cluster advancement decisions
     private int K;
-    private int reconciledOutputCount;
 
     // Track cluster exhaustion state for synchronized advancement
     private int[] currentClusterIndex; // Which cluster each component is currently on
@@ -77,17 +77,13 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
     private int totalTuplesPopped; // Total tuples popped from priority queue (including cancelled)
     private int antimatterTuplesDetected; // Antimatter tuples detected
     private int cancellationsMade; // Matter tuples cancelled by antimatter
+    private int getTupleCallCount; // Track how many times doGetTuple() is called
 
     // Full-scan mode flag (for merge operations)
     private boolean fullScanMode; // true = merge mode (sequential), false = query mode (distance-based)
 
     public LSMVCTreeSearchCursor(ILSMIndexOperationContext opCtx) {
         this(opCtx, false, false, NoOpIndexCursorStats.INSTANCE);
-    }
-
-    public LSMVCTreeSearchCursor(ILSMIndexOperationContext opCtx, boolean returnDeletedTuples,
-            IIndexCursorStats stats) {
-        this(opCtx, returnDeletedTuples, false, stats);
     }
 
     public LSMVCTreeSearchCursor(ILSMIndexOperationContext opCtx, boolean returnDeletedTuples, boolean fullScanMode,
@@ -106,12 +102,12 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
 
         // Extract K from search predicate for cluster advancement decisions
         this.K = extractK(searchPred);
-        this.reconciledOutputCount = 0;
 
         // Initialize debug counters
         this.totalTuplesPopped = 0;
         this.antimatterTuplesDetected = 0;
         this.cancellationsMade = 0;
+        this.getTupleCallCount = 0;
 
         // Set up comparator and operational components
         cmp = lsmInitialState.getOriginalKeyComparator();
@@ -125,9 +121,9 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
 
         // Initialize cluster tracking arrays for synchronized advancement
         currentClusterIndex = new int[numVCTrees];
-        java.util.Arrays.fill(currentClusterIndex, 0); // All start at cluster 0
+        Arrays.fill(currentClusterIndex, 0); // All start at cluster 0
         clusterExhausted = new boolean[numVCTrees];
-        java.util.Arrays.fill(clusterExhausted, false);
+        Arrays.fill(clusterExhausted, false);
         stopAdvancing = false;
 
         // Initialize or resize accessor/cursor arrays
@@ -215,7 +211,8 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
                 // Cursor has no data in initial cluster - mark as exhausted
                 clusterExhausted[i] = true;
                 System.err.println(String.format(
-                        "[LSMVCTreeSearchCursor] Component %d has empty initial cluster (marked exhausted)", i));
+                        "[LSMVCTreeSearchCursor] Component %d has empty initial cluster (marked exhausted)",
+                        i));
             }
         }
 
@@ -287,14 +284,12 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
 
     @Override
     public void doClose() throws HyracksDataException {
-        // Print final reconciliation summary for demo
+        // Print final reconciliation summary
         System.err.println("\n========== LSM Vector Index Search Summary ==========");
         System.err.println(String.format("Total tuples processed:     %d", totalTuplesPopped));
         System.err.println(String.format("Antimatter tuples detected: %d", antimatterTuplesDetected));
         System.err.println(String.format("Cancellations made:         %d", cancellationsMade));
-        System.err.println(String.format("Final output count:         %d", reconciledOutputCount));
-        System.err.println(String.format("Verification:               %d - %d = %d ✓", totalTuplesPopped,
-                cancellationsMade, reconciledOutputCount));
+        System.err.println(String.format("doGetTuple() was called:    %d times", getTupleCallCount));
         System.err.println("=====================================================\n");
 
         super.doClose();
@@ -314,8 +309,7 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
         outputElement = outputPriorityQueue.poll();
         needPushElementIntoQueue = true;
 
-        // Increment reconciled output count - this tuple is being returned to user
-        reconciledOutputCount++;
+        // Track total tuples popped (including those that may be cancelled)
         totalTuplesPopped++;
     }
 
@@ -345,12 +339,6 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
                         needPushElementIntoQueue = true;
                         antimatterTuplesDetected++;
 
-                        // LOG: Antimatter detected
-                        if (antimatterTuplesDetected <= 5 || antimatterTuplesDetected % 50 == 0) {
-                            System.err.println(
-                                    String.format("[checkPQ] Antimatter detected #%d | Component=%d, held for matching",
-                                            antimatterTuplesDetected, outputElement.getCursorIndex()));
-                        }
                         // Continue loop to check for cancellation with next tuple
                     } else {
                         // Valid output tuple - will be returned to user
@@ -368,29 +356,6 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
 
                         // Advance outputElement's cursor (don't lose the rest of its tuples!)
                         pushIntoQueueAndAdvanceClusterIfNeeded(outputElement);
-
-                        // CRITICAL FIX: Only decrement reconciledOutputCount if outputElement was a MATTER tuple
-                        // that was counted by doNext(). If outputElement is ANTIMATTER, it was detected at line 305
-                        // and never counted, so we should NOT decrement.
-                        boolean outputIsAntimatter = ((ILSMTreeTupleReference) outputElement.getTuple()).isAntimatter();
-                        if (!outputIsAntimatter) {
-                            // Matter tuple was counted by doNext(), decrement it
-                            reconciledOutputCount--;
-
-                            // Log cancellation (show every 50th)
-                            if (cancellationsMade % 50 == 0 || cancellationsMade <= 10) {
-                                System.err.println(String.format(
-                                        "[LSM Vector Index] Cancellation #%d | Matter tuple cancelled, reconciledCount=%d",
-                                        cancellationsMade, reconciledOutputCount));
-                            }
-                        } else {
-                            // Antimatter detected first, matter never counted, no decrement needed
-                            if (cancellationsMade % 50 == 0 || cancellationsMade <= 10) {
-                                System.err.println(String.format(
-                                        "[LSM Vector Index] Cancellation #%d | Antimatter matched, no count change",
-                                        cancellationsMade));
-                            }
-                        }
 
                         // Both tuples discarded (cancelled), reset state
                         needPushElementIntoQueue = false;
@@ -544,32 +509,44 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
             ITupleReference tupleB = elementB.getTuple();
 
             try {
-                // Compare field 0 (distance) - skip 1-byte type tag
-                // Field format: [type_tag:1 byte][double:8 bytes]
-                int result = cmp.getComparators()[0].compare(tupleA.getFieldData(0), tupleA.getFieldStart(0) + 1,
-                        tupleA.getFieldLength(0) - 1, tupleB.getFieldData(0), tupleB.getFieldStart(0) + 1,
-                        tupleB.getFieldLength(0) - 1);
+                // Tuple format: [distance, centroidId, primary_keys..., include_fields...]
+                // Compare order: distance first, then all remaining fields (PKs + includes)
+
+                // We skip centroidId since tuples from different clusters can coexist
+
+                // Compare field 0 (distance) using ADM-aware comparator 0
+                int result = cmp.getComparators()[0].compare(
+                    tupleA.getFieldData(0), tupleA.getFieldStart(0), tupleA.getFieldLength(0),
+                    tupleB.getFieldData(0), tupleB.getFieldStart(0), tupleB.getFieldLength(0));
 
                 if (result != 0) {
                     return result;
                 }
 
-                // Compare field 2 (primary_key) - skip 1-byte type tag
-                // Field format: [type_tag:1 byte][long:8 bytes]
-                result = cmp.getComparators()[1].compare(tupleA.getFieldData(2), tupleA.getFieldStart(2) + 1,
-                        tupleA.getFieldLength(2) - 1, tupleB.getFieldData(2), tupleB.getFieldStart(2) + 1,
-                        tupleB.getFieldLength(2) - 1);
+                // Compare remaining fields starting at field 2 (include fields + primary keys)
+                // We compare all fields for total ordering in the priority queue
+                int numRemainingFields = cmp.getComparators().length - 2;  // All fields after distance and centroidId
+                for (int i = 0; i < numRemainingFields; i++) {
+                    int fieldIdx = 2 + i;
+                    int cmpIdx = 2 + i;
 
-                if (result != 0) {
-                    return result;
+                    // Check if field exists in tuple before comparing
+                    if (fieldIdx >= tupleA.getFieldCount() || fieldIdx >= tupleB.getFieldCount()) {
+                        break;  // One tuple has fewer fields, skip remaining comparisons
+                    }
+
+                    result = cmp.getComparators()[cmpIdx].compare(
+                        tupleA.getFieldData(fieldIdx), tupleA.getFieldStart(fieldIdx), tupleA.getFieldLength(fieldIdx),
+                        tupleB.getFieldData(fieldIdx), tupleB.getFieldStart(fieldIdx), tupleB.getFieldLength(fieldIdx));
+                    if (result != 0) {
+                        return result;
+                    }
                 }
             } catch (Throwable e) {
-                System.err.println(String.format("[VectorPQComparator] ERROR comparing tuples: %s - %s",
-                        e.getClass().getSimpleName(), e.getMessage()));
                 throw new IllegalArgumentException(e);
             }
 
-            // Tiebreaker: prefer tuples from earlier components (lower cursor index)
+            // Tiebreaker: prefer tuples from earlier components
             if (elementA.getCursorIndex() > elementB.getCursorIndex()) {
                 return 1;
             } else {
@@ -580,6 +557,9 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
 
     @Override
     public ITupleReference doGetTuple() {
+        // Track how many times this method is called
+        getTupleCallCount++;
+
         // Return tuple from priority queue output element
         return outputElement != null ? outputElement.getTuple() : null;
     }
@@ -588,53 +568,57 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
     protected int compare(MultiComparator cmp, ITupleReference tupleA, ITupleReference tupleB)
             throws HyracksDataException {
 
-        // Compare field 0 (distance) - skip type_tag (1 byte)
-        // Field format: [type_tag:1 byte][double:8 bytes]
-        int result = cmp.getComparators()[0].compare(tupleA.getFieldData(0), tupleA.getFieldStart(0) + 1,
-                tupleA.getFieldLength(0) - 1, tupleB.getFieldData(0), tupleB.getFieldStart(0) + 1,
-                tupleB.getFieldLength(0) - 1);
+        // Tuple format: [distance, centroidId, primary_keys..., include_fields...]
+        // Compare order: distance first, then primary keys (skip centroidId)
+        // TODO: In the future, we may implement filtered search based on INCLUDE fields
+        //       to support predicates like "WHERE movie_year > 2000" during vector search
+
+        // Compare field 0 (distance) using ADM-aware comparator 0
+        int result = cmp.getComparators()[0].compare(
+            tupleA.getFieldData(0), tupleA.getFieldStart(0), tupleA.getFieldLength(0),
+            tupleB.getFieldData(0), tupleB.getFieldStart(0), tupleB.getFieldLength(0));
 
         if (result != 0) {
             return result;
         }
 
-        // Compare field 2 (primary_key) - skip type_tag (1 byte)
-        // Field format: [type_tag:1 byte][long:8 bytes] or [type_tag:1 byte][string]
-        return cmp.getComparators()[1].compare(tupleA.getFieldData(2), tupleA.getFieldStart(2) + 1,
-                tupleA.getFieldLength(2) - 1, tupleB.getFieldData(2), tupleB.getFieldStart(2) + 1,
-                tupleB.getFieldLength(2) - 1);
+        // Compare remaining fields starting at field 2 (include fields + primary keys)
+        // Comparators array: [0=distance, 1=centroidId, 2+=include/PK fields]
+        // We skip comparator 1 (centroidId) since tuples from different clusters can coexist
+        // We compare all remaining fields for total ordering
+        int numRemainingFields = cmp.getComparators().length - 2;
+        for (int i = 0; i < numRemainingFields; i++) {
+            int fieldIdx = 2 + i;
+            int cmpIdx = 2 + i;
+
+            // Check if field exists in tuple before comparing
+            if (fieldIdx >= tupleA.getFieldCount() || fieldIdx >= tupleB.getFieldCount()) {
+                break;  // One tuple has fewer fields, skip remaining comparisons
+            }
+
+            result = cmp.getComparators()[cmpIdx].compare(
+                tupleA.getFieldData(fieldIdx), tupleA.getFieldStart(fieldIdx), tupleA.getFieldLength(fieldIdx),
+                tupleB.getFieldData(fieldIdx), tupleB.getFieldStart(fieldIdx), tupleB.getFieldLength(fieldIdx));
+            if (result != 0) {
+                return result;
+            }
+        }
+
+        return 0;
     }
 
     /**
-     * Helper method to decode primary key for debugging.
-     * Handles both LONG and STRING types.
+     * Determine number of include fields from tuple field count.
+     * Tuple format: [distance, centroidId, primary_keys..., include_fields...]
+     *
+     * TODO: Currently returns 0 (no includes handled in comparison).
+     *       In the future, this will be passed from index metadata to support
+     *       filtered vector search based on INCLUDE field predicates.
      */
-    private String decodePrimaryKey(byte[] data, int start, int length, byte typeTag) {
-        try {
-            // Type tag values: LONG=18, STRING=1 (common AsterixDB type tags)
-            if (typeTag == 18) {
-                // LONG type (8 bytes)
-                if (length >= 9) {
-                    long value = java.nio.ByteBuffer.wrap(data, start + 1, 8).getLong();
-                    return String.valueOf(value);
-                }
-            } else if (typeTag == 1) {
-                // STRING type (2-byte length prefix + UTF-8 bytes)
-                if (length >= 3) {
-                    int strLen = java.nio.ByteBuffer.wrap(data, start + 1, 2).getShort() & 0xFFFF;
-                    String value = new String(data, start + 3, strLen, java.nio.charset.StandardCharsets.UTF_8);
-                    return value;
-                }
-            }
-            // Unknown type or invalid length - return hex representation
-            StringBuilder hex = new StringBuilder();
-            for (int i = 1; i < Math.min(length, 20); i++) {
-                hex.append(String.format("%02X", data[start + i]));
-            }
-            return "0x" + hex.toString();
-        } catch (Exception e) {
-            return "<decode_error>";
-        }
+    private int getNumIncludeFields(ITupleReference tuple) {
+        // Total fields = 2 (distance, centroidId) + numPKs + numIncludes
+        // For now, assume no includes (they're not used in comparison anyway)
+        return 0;
     }
 
     @Override
@@ -685,7 +669,8 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
         // Current cluster exhausted for THIS component
         clusterExhausted[cursorIndex] = true;
 
-        System.err.println(String.format("[LSMVCTreeSearchCursor] Component %d cluster exhausted (cluster_index=%d)",
+        System.err.println(String.format(
+                "[LSMVCTreeSearchCursor] Component %d cluster exhausted (cluster_index=%d)",
                 cursorIndex, currentClusterIndex[cursorIndex]));
 
         // Check if ALL components have exhausted their current cluster
@@ -701,14 +686,15 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
             // Some components still have data in their current cluster
             // Don't advance yet - wait for all to exhaust
             System.err.println(String.format(
-                    "[LSMVCTreeSearchCursor] Component %d exhausted, but waiting for other components", cursorIndex));
+                    "[LSMVCTreeSearchCursor] Component %d exhausted, but waiting for other components",
+                    cursorIndex));
             return;
         }
 
         // ALL components exhausted their current cluster
         System.err.println(String.format(
-                "[LSMVCTreeSearchCursor] ALL components exhausted cluster %d, reconciledOutputCount=%d, K=%d",
-                currentClusterIndex[0], reconciledOutputCount, K));
+                "[LSMVCTreeSearchCursor] ALL components exhausted cluster %d, K=%d",
+                currentClusterIndex[0], K));
 
         // Decision: Should we advance ALL components to next cluster?
         if (stopAdvancing) {
@@ -716,15 +702,21 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
             return;
         }
 
-        if (reconciledOutputCount >= K) {
-            // Reached K - stop advancing all components
+        // K-based early termination: Check if we've already returned K tuples
+        // getTupleCallCount tracks actual outputs returned to user (incremented in doGetTuple)
+        if (getTupleCallCount >= K) {
+            // We have enough results - set flag to stop advancing
             stopAdvancing = true;
-            System.err.println(String.format("[LSMVCTreeSearchCursor] Reached K=%d, stopping cluster advancement", K));
+            System.err.println(String.format(
+                    "[LSMVCTreeSearchCursor] K-based early termination: returned %d tuples (K=%d), stopping cluster advancement",
+                    getTupleCallCount, K));
             return;
         }
 
-        // Need more data - advance ALL components to next cluster together
-        System.err.println("[LSMVCTreeSearchCursor] Advancing ALL components to next cluster");
+        // Not enough results yet - advance ALL components to next cluster together
+        System.err.println(String.format(
+                "[LSMVCTreeSearchCursor] Need more results (%d < K=%d), advancing to next cluster",
+                getTupleCallCount, K));
         advanceAllComponentsToNextCluster();
     }
 
@@ -734,7 +726,7 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
      */
     private void advanceAllComponentsToNextCluster() throws HyracksDataException {
         // Reset exhaustion flags for new cluster
-        java.util.Arrays.fill(clusterExhausted, false);
+        Arrays.fill(clusterExhausted, false);
 
         for (int i = 0; i < rangeCursors.length; i++) {
             IIndexCursor cursor = rangeCursors[i];
@@ -743,16 +735,20 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
                 // Not a VectorClusteringSearchCursor - mark as exhausted
                 clusterExhausted[i] = true;
                 System.err.println(String.format(
-                        "[LSMVCTreeSearchCursor] Component %d is not VectorClusteringSearchCursor, skipping", i));
+                        "[LSMVCTreeSearchCursor] Component %d is not VectorClusteringSearchCursor, skipping",
+                        i));
                 continue;
             }
 
-            VectorClusteringSearchCursor vcCursor = (VectorClusteringSearchCursor) cursor;
+            VectorClusteringSearchCursor vcCursor =
+                    (VectorClusteringSearchCursor) cursor;
 
             if (!vcCursor.hasMoreClusters()) {
                 // No more clusters for this component - mark as exhausted
                 clusterExhausted[i] = true;
-                System.err.println(String.format("[LSMVCTreeSearchCursor] Component %d has no more clusters", i));
+                System.err.println(String.format(
+                        "[LSMVCTreeSearchCursor] Component %d has no more clusters",
+                        i));
                 continue;
             }
 
@@ -761,8 +757,9 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
             if (!advanced) {
                 // Failed to advance (no more clusters or error)
                 clusterExhausted[i] = true;
-                System.err.println(
-                        String.format("[LSMVCTreeSearchCursor] Component %d failed to advance to next cluster", i));
+                System.err.println(String.format(
+                        "[LSMVCTreeSearchCursor] Component %d failed to advance to next cluster",
+                        i));
                 continue;
             }
 
@@ -776,16 +773,16 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
                 PriorityQueueElement pqe = pqes[i];
                 pqe.reset(vcCursor.getTuple());
                 outputPriorityQueue.offer(pqe);
-                System.err
-                        .println(String.format("[LSMVCTreeSearchCursor] Component %d advanced to cluster %d (has data)",
-                                i, currentClusterIndex[i]));
+                System.err.println(String.format(
+                        "[LSMVCTreeSearchCursor] Component %d advanced to cluster %d (has data)",
+                        i, currentClusterIndex[i]));
             } else {
                 // Cluster is empty - mark as exhausted for this cluster
                 // Component will wait at this cluster until all components finish
                 clusterExhausted[i] = true;
                 System.err.println(String.format(
-                        "[LSMVCTreeSearchCursor] Component %d cluster %d is empty (will wait for other components)", i,
-                        currentClusterIndex[i]));
+                        "[LSMVCTreeSearchCursor] Component %d cluster %d is empty (will wait for other components)",
+                        i, currentClusterIndex[i]));
             }
         }
 
@@ -815,9 +812,9 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
                     "[LSMVCTreeSearchCursor] ALL components found cluster %d empty, skipping to next cluster",
                     currentClusterIndex[0]));
 
-            // Check if we've reached K or should stop advancing
-            if (stopAdvancing || reconciledOutputCount >= K) {
-                System.err.println("[LSMVCTreeSearchCursor] Reached K or stop flag, halting advancement");
+            // Check if we've decided to stop advancing
+            if (stopAdvancing) {
+                System.err.println("[LSMVCTreeSearchCursor] Reached stop flag, halting advancement");
                 return;
             }
 

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/VectorClusteringTreeFactory.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/VectorClusteringTreeFactory.java
@@ -25,6 +25,7 @@ import org.apache.hyracks.api.io.IIOManager;
 import org.apache.hyracks.storage.am.common.api.IPageManagerFactory;
 import org.apache.hyracks.storage.am.common.api.ITreeIndexFrameFactory;
 import org.apache.hyracks.storage.am.lsm.common.impls.TreeIndexFactory;
+import org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessorFactory;
 import org.apache.hyracks.storage.am.vector.impls.VectorClusteringTree;
 import org.apache.hyracks.storage.common.buffercache.IBufferCache;
 
@@ -39,23 +40,25 @@ public class VectorClusteringTreeFactory extends TreeIndexFactory<VectorClusteri
     private final ITreeIndexFrameFactory metadataFrameFactory;
     private final ITreeIndexFrameFactory dataFrameFactory;
     private final int vectorDimensions;
+    private final IVectorBinaryAccessorFactory vectorAccessorFactory;
 
     public VectorClusteringTreeFactory(IIOManager ioManager, IBufferCache bufferCache,
             IPageManagerFactory freePageManagerFactory, ITreeIndexFrameFactory interiorFrameFactory,
             ITreeIndexFrameFactory leafFrameFactory, ITreeIndexFrameFactory metadataFrameFactory,
             ITreeIndexFrameFactory dataFrameFactory, IBinaryComparatorFactory[] cmpFactories, int fieldCount,
-            int vectorDimensions) {
+            int vectorDimensions, IVectorBinaryAccessorFactory vectorAccessorFactory) {
         super(ioManager, bufferCache, freePageManagerFactory, interiorFrameFactory, leafFrameFactory, cmpFactories,
                 fieldCount);
         this.metadataFrameFactory = metadataFrameFactory;
         this.dataFrameFactory = dataFrameFactory;
         this.vectorDimensions = vectorDimensions;
+        this.vectorAccessorFactory = vectorAccessorFactory;
     }
 
     @Override
     public VectorClusteringTree createIndexInstance(FileReference file) {
         return new VectorClusteringTree(bufferCache, freePageManagerFactory.createPageManager(bufferCache),
                 interiorFrameFactory, leafFrameFactory, metadataFrameFactory, dataFrameFactory, cmpFactories,
-                vectorDimensions, vectorDimensions, file);
+                vectorDimensions, vectorDimensions, file, vectorAccessorFactory);
     }
 }

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/tuples/LSMVCTreeDataTupleReference.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/tuples/LSMVCTreeDataTupleReference.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hyracks.storage.am.lsm.vector.tuples;
+
+import org.apache.hyracks.api.dataflow.value.ITypeTraits;
+import org.apache.hyracks.storage.am.common.api.ITreeIndexFrame;
+import org.apache.hyracks.storage.am.common.tuples.TypeAwareTupleReference;
+import org.apache.hyracks.storage.am.common.util.BitOperationUtils;
+import org.apache.hyracks.storage.am.lsm.common.api.ILSMTreeTupleReference;
+
+/**
+ * Tuple reference for LSM Vector Clustering Tree data frames.
+ * Handles tuples with format:
+ * - Matter tuple: <distance:ADOUBLE, centroid_id:AINTEGER, primary_key:ALONG>
+ * - Anti-matter tuple: <primary_key:ALONG> only (deletion marker)
+ */
+public class LSMVCTreeDataTupleReference extends TypeAwareTupleReference implements ILSMTreeTupleReference {
+
+    // Indicates whether the last call to setFieldCount() was initiated by
+    // the outside or whether it was called internally to set up an
+    // antimatter tuple.
+    private boolean resetFieldCount = false;
+
+    // Primary key is the last field (field 2) in matter tuples, only field in antimatter tuples
+    private final int numKeyFields = 1;
+
+    // Total number of fields in a matter tuple: distance, centroid_id, primary_key
+    private final int totalMatterFields;
+
+    public LSMVCTreeDataTupleReference(ITypeTraits[] typeTraits, ITypeTraits nullTypeTraits) {
+        super(typeTraits, nullTypeTraits);
+        this.totalMatterFields = typeTraits.length;
+    }
+
+    @Override
+    public void setFieldCount(int fieldCount) {
+        super.setFieldCount(fieldCount);
+        // Don't change the fieldCount in reset calls.
+        resetFieldCount = false;
+    }
+
+    @Override
+    public void setFieldCount(int fieldStartIndex, int fieldCount) {
+        super.setFieldCount(fieldStartIndex, fieldCount);
+        // Don't change the fieldCount in reset calls.
+        resetFieldCount = false;
+    }
+
+    @Override
+    public void resetByTupleOffset(byte[] buf, int tupleStartOff) {
+        this.buf = buf;
+        this.tupleStartOff = tupleStartOff;
+
+        // NOTE: Both matter and antimatter tuples have the same structure (all fields)
+        // The only difference is the antimatter bit (bit 7) in the null flags byte
+        // No field count adjustment needed - both have totalMatterFields (3 fields)
+
+        super.resetByTupleOffset(buf, tupleStartOff);
+    }
+
+    @Override
+    public void resetByTupleIndex(ITreeIndexFrame frame, int tupleIndex) {
+        resetByTupleOffset(frame.getBuffer().array(), frame.getTupleOffset(tupleIndex));
+    }
+
+    @Override
+    protected int getNullFlagsBytes() {
+        // number of fields + matter/antimatter bit
+        int numBits = fieldCount + 1;
+        return BitOperationUtils.getFlagBytes(numBits);
+    }
+
+    @Override
+    public boolean isAntimatter() {
+        // Check antimatter bit (bit 7 in null flags byte)
+        return BitOperationUtils.getBit(buf, tupleStartOff, ANTIMATTER_BIT_OFFSET);
+    }
+
+    public int getTupleStart() {
+        return tupleStartOff;
+    }
+
+    @Override
+    protected int getAdjustedFieldIdx(int fieldIdx) {
+        // 1 bit for antimatter (vector index doesn't use update-aware)
+        return fieldIdx + 1;
+    }
+}

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/tuples/LSMVCTreeDataTupleWriter.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/tuples/LSMVCTreeDataTupleWriter.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hyracks.storage.am.lsm.vector.tuples;
+
+import static org.apache.hyracks.storage.am.lsm.common.api.ILSMTreeTupleReference.ANTIMATTER_BIT_OFFSET;
+
+import org.apache.hyracks.api.dataflow.value.ITypeTraits;
+import org.apache.hyracks.dataflow.common.data.accessors.ITupleReference;
+import org.apache.hyracks.storage.am.common.api.INullIntrospector;
+import org.apache.hyracks.storage.am.common.tuples.TypeAwareTupleWriter;
+import org.apache.hyracks.storage.am.common.util.BitOperationUtils;
+import org.apache.hyracks.storage.am.lsm.common.api.ILSMTreeTupleWriter;
+
+/**
+ * Tuple writer for LSM Vector Clustering Tree data frames.
+ *
+ * Handles data tuples with dynamic format: <distance, centroid_id, primary_keys..., include_fields...>
+ *
+ * The number of fields is determined by typeTraits.length (passed in constructor):
+ * - Minimum: 3 fields (distance, centroid_id, 1 primary key)
+ * - With includes: 2 + numPrimaryKeys + numIncludeFields
+ *
+ * Anti-matter tuples (deletion markers) have the same fields as matter tuples,
+ * but with bit 7 (ANTIMATTER_BIT) set in the null flags byte.
+ *
+ * This follows the LSM pattern where anti-matter tuples logically delete records
+ * without physically removing them until merge operations.
+ */
+public class LSMVCTreeDataTupleWriter extends TypeAwareTupleWriter implements ILSMTreeTupleWriter {
+
+    private boolean isAntimatter;
+
+    public LSMVCTreeDataTupleWriter(ITypeTraits[] typeTraits, ITypeTraits nullTypeTraits,
+            INullIntrospector nullIntrospector) {
+        super(typeTraits, nullTypeTraits, nullIntrospector);
+        this.isAntimatter = false;
+    }
+
+    @Override
+    public int bytesRequired(ITupleReference tuple) {
+        // Anti-matter tuple has same size as matter tuple (all fields stored)
+        return super.bytesRequired(tuple);
+    }
+
+    @Override
+    public int getCopySpaceRequired(ITupleReference tuple) {
+        return super.bytesRequired(tuple);
+    }
+
+    @Override
+    public LSMVCTreeDataTupleReference createTupleReference() {
+        return new LSMVCTreeDataTupleReference(typeTraits, nullTypeTraits);
+    }
+
+    @Override
+    protected int getNullFlagsBytes(int numFields) {
+        // numFields + antimatter bit (no update-aware for vector index)
+        int numBits = numFields + 1;
+        return BitOperationUtils.getFlagBytes(numBits);
+    }
+
+    @Override
+    protected int getNullFlagsBytes(ITupleReference tuple) {
+        // # of fields + antimatter bit
+        int numBits = tuple.getFieldCount() + 1;
+        return BitOperationUtils.getFlagBytes(numBits);
+    }
+
+    @Override
+    public int writeTuple(ITupleReference tuple, byte[] targetBuf, int targetOff) {
+        // Write all fields (same for matter and antimatter)
+        int bytesWritten = super.writeTuple(tuple, targetBuf, targetOff);
+
+//        System.err.println("[LSMVCTreeDataTupleWriter.writeTuple] isAntimatter=" + isAntimatter +
+//                          ", Thread=" + Thread.currentThread().getId());
+
+        if (isAntimatter) {
+            // Only difference: set antimatter bit (bit 7) in null flags byte
+            BitOperationUtils.setBit(targetBuf, targetOff, ANTIMATTER_BIT_OFFSET);
+//            System.err.println("[LSMVCTreeDataTupleWriter.writeTuple] ANTIMATTER BIT SET!");
+        }
+
+        return bytesWritten;
+    }
+
+    @Override
+    public void setAntimatter(boolean isDelete) {
+        this.isAntimatter = isDelete;
+    }
+
+    @Override
+    protected int getAdjustedFieldIdx(int fieldIdx) {
+        // 1 bit for antimatter (vector index doesn't use update-aware)
+        return fieldIdx + 1;
+    }
+}

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/tuples/LSMVCTreeDataTupleWriterFactory.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/tuples/LSMVCTreeDataTupleWriterFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hyracks.storage.am.lsm.vector.tuples;
+
+import org.apache.hyracks.api.dataflow.value.ITypeTraits;
+import org.apache.hyracks.storage.am.common.api.INullIntrospector;
+import org.apache.hyracks.storage.am.common.api.ITreeIndexTupleWriter;
+import org.apache.hyracks.storage.am.common.api.ITreeIndexTupleWriterFactory;
+
+/**
+ * Factory for creating LSMVCTreeDataTupleWriter instances.
+ *
+ * Used to create tuple writers for vector index data frames with anti-matter support.
+ */
+public class LSMVCTreeDataTupleWriterFactory implements ITreeIndexTupleWriterFactory {
+
+    private static final long serialVersionUID = 1L;
+
+    private final ITypeTraits[] typeTraits;
+    private final ITypeTraits nullTypeTraits;
+    private final INullIntrospector nullIntrospector;
+    private final boolean isAntimatter;
+
+    public LSMVCTreeDataTupleWriterFactory(ITypeTraits[] typeTraits, boolean isAntimatter,
+            ITypeTraits nullTypeTraits, INullIntrospector nullIntrospector) {
+        this.typeTraits = typeTraits;
+        this.isAntimatter = isAntimatter;
+        this.nullTypeTraits = nullTypeTraits;
+        this.nullIntrospector = nullIntrospector;
+    }
+
+    @Override
+    public ITreeIndexTupleWriter createTupleWriter() {
+        LSMVCTreeDataTupleWriter writer = new LSMVCTreeDataTupleWriter(typeTraits, nullTypeTraits, nullIntrospector);
+        writer.setAntimatter(isAntimatter);
+        return writer;
+    }
+}

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/utils/LSMVCTreeUtils.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/utils/LSMVCTreeUtils.java
@@ -52,6 +52,7 @@ import org.apache.hyracks.storage.am.lsm.vector.impls.LSMVCTree;
 import org.apache.hyracks.storage.am.lsm.vector.impls.LSMVCTreeDiskComponentFactory;
 import org.apache.hyracks.storage.am.lsm.vector.impls.LSMVCTreeFileManager;
 import org.apache.hyracks.storage.am.lsm.vector.impls.VectorClusteringTreeFactory;
+import org.apache.hyracks.storage.am.lsm.vector.tuples.LSMVCTreeDataTupleWriterFactory;
 import org.apache.hyracks.storage.am.vector.frames.VectorClusteringDataFrameFactory;
 import org.apache.hyracks.storage.am.vector.frames.VectorClusteringInteriorFrameFactory;
 import org.apache.hyracks.storage.am.vector.frames.VectorClusteringLeafFrameFactory;
@@ -108,11 +109,12 @@ public class LSMVCTreeUtils {
             boolean needKeyDupCheck, int vectorDimensions, int[] vectorFields, int[] filterFields,
             ILSMComponentFilterFrameFactory filterFrameFactory, LSMComponentFilterManager filterManager,
             IComponentFilterHelper filterHelper, boolean durable,
-            IMetadataPageManagerFactory metadataPageManagerFactory, boolean atomic, RecordDescriptor inputRecDesc)
+            IMetadataPageManagerFactory metadataPageManagerFactory, boolean atomic, RecordDescriptor inputRecDesc,
+            org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessorFactory vectorAccessorFactory)
             throws HyracksDataException {
 
-        //        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-        //                + "] LSMVCTreeUtils.createLSMTree: Method started");
+//        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
+//                + "] LSMVCTreeUtils.createLSMTree: Method started");
         // We need null-related types for tuple writers - use simple defaults for testing
         ITypeTraits nullTypeTraits = null; // Can be null for basic testing
         INullIntrospector nullIntrospector = null; // Can be null for basic testing
@@ -129,12 +131,10 @@ public class LSMVCTreeUtils {
         metadataTypeTraits[0] = DoublePointable.TYPE_TRAITS; // max distance (double) - Fixed 8 bytes
         metadataTypeTraits[1] = IntegerPointable.TYPE_TRAITS; // page pointer (int) - Fixed 4 bytes
 
-        // Data frames need 4-field data tuples: <distance, cosine_similarity, vector, primary_key>
-        ITypeTraits[] dataTypeTraits = new ITypeTraits[3];
-        dataTypeTraits[0] = new FixedLengthTypeTrait(9); // distance (double) - Fixed 8 bytes
-        dataTypeTraits[1] = new FixedLengthTypeTrait(5); // cosine similarity (double) - Fixed 8 bytes
-        //        dataTypeTraits[2] = VarLengthTypeTrait.INSTANCE; // vector (float array) - Variable
-        dataTypeTraits[2] = new FixedLengthTypeTrait(9); // primary key (string/variable) - Variable
+        // Data frames: Use the typeTraits parameter (passed from VCTreeResourceFactoryProvider)
+        // Format: [distance: DOUBLE, centroidId: INT32, primary_keys..., include_fields...]
+        // The typeTraits parameter contains the correct ADM-tagged type traits for all fields
+        ITypeTraits[] dataTypeTraits = typeTraits;
 
         // Create individual tuple writer factories with correct type traits for each frame type
         VectorClusteringInteriorTupleWriterFactory interiorTupleWriterFactory =
@@ -143,11 +143,16 @@ public class LSMVCTreeUtils {
                 new VectorClusteringLeafTupleWriterFactory(clusterTypeTraits, nullTypeTraits, nullIntrospector);
         VectorClusteringMetadataTupleWriterFactory metadataTupleWriterFactory =
                 new VectorClusteringMetadataTupleWriterFactory(metadataTypeTraits, nullTypeTraits, nullIntrospector);
-        VectorClusteringDataTupleWriterFactory dataTupleWriterFactory =
-                new VectorClusteringDataTupleWriterFactory(dataTypeTraits, nullTypeTraits, nullIntrospector);
+        // Create separate tuple writer factories for INSERT and DELETE operations (LSMBTree pattern)
+        // Insert operations use matter tuples (isAntimatter=false)
+        LSMVCTreeDataTupleWriterFactory insertDataTupleWriterFactory =
+                new LSMVCTreeDataTupleWriterFactory(dataTypeTraits, false, nullTypeTraits, nullIntrospector);
+        // Delete operations use antimatter tuples (isAntimatter=true)
+        LSMVCTreeDataTupleWriterFactory deleteDataTupleWriterFactory =
+                new LSMVCTreeDataTupleWriterFactory(dataTypeTraits, true, nullTypeTraits, nullIntrospector);
 
-        //        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-        //                + "] LSMVCTreeUtils.createLSMTree: Tuple writer factories created");
+//        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
+//                + "] LSMVCTreeUtils.createLSMTree: Tuple writer factories created");
         // Create tuple writers from factories
         ITreeIndexTupleWriter interiorTupleWriter = interiorTupleWriterFactory.createTupleWriter();
         ITreeIndexTupleWriter leafTupleWriter = leafTupleWriterFactory.createTupleWriter();
@@ -160,37 +165,42 @@ public class LSMVCTreeUtils {
                 new VectorClusteringLeafFrameFactory(leafTupleWriter, vectorDimensions);
         ITreeIndexFrameFactory metadataFrameFactory =
                 new VectorClusteringMetadataFrameFactory(metadataTupleWriter, vectorDimensions);
-        ITreeIndexFrameFactory dataFrameFactory =
-                new VectorClusteringDataFrameFactory(dataTupleWriterFactory, vectorDimensions);
+        // Create two data frame factories following LSMBTree pattern
+        ITreeIndexFrameFactory insertDataFrameFactory =
+                new VectorClusteringDataFrameFactory(insertDataTupleWriterFactory, vectorDimensions);
+        ITreeIndexFrameFactory deleteDataFrameFactory =
+                new VectorClusteringDataFrameFactory(deleteDataTupleWriterFactory, vectorDimensions);
 
-        //        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-        //                + "] LSMVCTreeUtils.createLSMTree: Frame factories created");
+//        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
+//                + "] LSMVCTreeUtils.createLSMTree: Frame factories created");
+        // VectorClusteringTreeFactory is used for disk components, which are immutable
+        // Disk components always use insertDataFrameFactory (no in-place deletes)
         VectorClusteringTreeFactory vctreeFactory = new VectorClusteringTreeFactory(ioManager, diskBufferCache,
                 metadataPageManagerFactory, interiorFrameFactory, leafFrameFactory, metadataFrameFactory,
-                dataFrameFactory, cmpFactories, 4, vectorDimensions);
-        //        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-        //                + "] LSMVCTreeUtils.createLSMTree: VectorClusteringTreeFactory created");
+                insertDataFrameFactory, cmpFactories, 4, vectorDimensions, vectorAccessorFactory);
+//        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
+//                + "] LSMVCTreeUtils.createLSMTree: VectorClusteringTreeFactory created");
         // Create file manager for LSM components
         ILSMIndexFileManager fileManager = new LSMVCTreeFileManager(ioManager, file, vctreeFactory);
-        //        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-        //                + "] LSMVCTreeUtils.createLSMTree: LSMVCTreeFileManager created");
+//        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
+//                + "] LSMVCTreeUtils.createLSMTree: LSMVCTreeFileManager created");
 
         // Create disk component factory
         ILSMDiskComponentFactory componentFactory = new LSMVCTreeDiskComponentFactory(vctreeFactory, filterHelper);
-        //        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-        //                + "] LSMVCTreeUtils.createLSMTree: LSMVCTreeDiskComponentFactory created");
+//        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
+//                + "] LSMVCTreeUtils.createLSMTree: LSMVCTreeDiskComponentFactory created");
 
-        // Create the LSMVCTree instance
-        //        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-        //                + "] LSMVCTreeUtils.createLSMTree: About to create LSMVCTree instance");
+        // Create the LSMVCTree instance with both insert and delete data frame factories
+//        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
+//                + "] LSMVCTreeUtils.createLSMTree: About to create LSMVCTree instance");
         LSMVCTree result = new LSMVCTree(storageConfig, ioManager, virtualBufferCaches, interiorFrameFactory,
-                leafFrameFactory, metadataFrameFactory, dataFrameFactory, diskBufferCache, fileManager,
-                componentFactory, componentFactory, filterHelper, filterFrameFactory, filterManager,
-                bloomFilterFalsePositiveRate, cmpFactories, mergePolicy, opTracker, ioScheduler, ioOpCallbackFactory,
-                pageWriteCallbackFactory, needKeyDupCheck, vectorDimensions, vectorFields, filterFields, durable,
-                atomic);
-        //        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
-        //                + "] LSMVCTreeUtils.createLSMTree: LSMVCTree instance created successfully");
+                leafFrameFactory, metadataFrameFactory, insertDataFrameFactory, deleteDataFrameFactory,
+                diskBufferCache, fileManager, componentFactory, componentFactory, filterHelper, filterFrameFactory,
+                filterManager, bloomFilterFalsePositiveRate, cmpFactories, mergePolicy, opTracker, ioScheduler,
+                ioOpCallbackFactory, pageWriteCallbackFactory, needKeyDupCheck, vectorDimensions, vectorFields,
+                filterFields, durable, atomic, vectorAccessorFactory);
+//        System.err.println("[THREAD:" + Thread.currentThread().getId() + "] [TIME:" + System.currentTimeMillis()
+//                + "] LSMVCTreeUtils.createLSMTree: LSMVCTree instance created successfully");
         return result;
     }
 
@@ -225,7 +235,8 @@ public class LSMVCTreeUtils {
             ILSMMergePolicy mergePolicy, ILSMOperationTracker opTracker, ILSMIOOperationScheduler ioScheduler,
             ILSMIOOperationCallbackFactory ioOpCallbackFactory, ILSMPageWriteCallbackFactory pageWriteCallbackFactory,
             boolean needKeyDupCheck, int vectorDimensions, int[] vectorFields, int[] filterFields, boolean durable,
-            IMetadataPageManagerFactory metadataPageManagerFactory, RecordDescriptor inputRecDesc)
+            IMetadataPageManagerFactory metadataPageManagerFactory, RecordDescriptor inputRecDesc,
+            org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessorFactory vectorAccessorFactory)
             throws HyracksDataException {
 
         // Use default configurations for simplified creation
@@ -238,6 +249,6 @@ public class LSMVCTreeUtils {
                 cmpFactories, bloomFilterFalsePositiveRate, mergePolicy, opTracker, ioScheduler, ioOpCallbackFactory,
                 pageWriteCallbackFactory, needKeyDupCheck, vectorDimensions, vectorFields, filterFields,
                 filterFrameFactory, filterManager, filterHelper, durable, metadataPageManagerFactory, atomic,
-                inputRecDesc);
+                inputRecDesc, vectorAccessorFactory);
     }
 }

--- a/hyracks-fullstack/hyracks/hyracks-test-support/src/main/java/org/apache/hyracks/storage/am/vector/VectorTreeUtils.java
+++ b/hyracks-fullstack/hyracks/hyracks-test-support/src/main/java/org/apache/hyracks/storage/am/vector/VectorTreeUtils.java
@@ -119,7 +119,7 @@ public class VectorTreeUtils {
                 new VectorClusteringDataFrameFactory(dataTupleWriterFactory, vectorDimensions);
 
         return new VectorClusteringTree(bufferCache, pageManager, interiorFrameFactory, leafFrameFactory,
-                metadataFrameFactory, dataFrameFactory, cmpFactories, 4, vectorDimensions, file);
+                metadataFrameFactory, dataFrameFactory, cmpFactories, 4, vectorDimensions, file, null);
     }
 
     /**

--- a/hyracks-fullstack/hyracks/hyracks-tests/hyracks-storage-am-lsm-btree-test/src/test/java/org/apache/hyracks/storage/am/lsm/vector/util/LSMVCTreeTestContext.java
+++ b/hyracks-fullstack/hyracks/hyracks-tests/hyracks-storage-am-lsm-btree-test/src/test/java/org/apache/hyracks/storage/am/lsm/vector/util/LSMVCTreeTestContext.java
@@ -107,7 +107,7 @@ public final class LSMVCTreeTestContext extends AbstractVectorTreeTestContext {
                 null, // filterFields (no filter fields)
                 true, // durable
                 metadataPageManagerFactory, // metadataPageManagerFactory
-                null); // inputRecDesc (can be null for testing)
+                null, null); // inputRecDesc (can be null for testing)
 
         LSMVCTreeTestContext testCtx = new LSMVCTreeTestContext(fieldSerdes, lsmVCTree, numVectorFields);
         return testCtx;


### PR DESCRIPTION
Refactor vector index tuple handling to support variable numbers of primary keys and INCLUDE fields. Changes tuple format from hardcoded 3-field structure to dynamic format: [distance, centroidId, primary_keys..., include_fields...]. Key changes:
- VCTreeResourceFactoryProvider: Generate type traits and comparators based on actual primary key count and INCLUDE field count from index metadata
- LSMVCTree: Add getCmpFactories() to expose ADM-aware comparator factories
- LSMVCTreeOpContext: Use ADM-aware comparators from LSMVCTree instead of hardcoded comparators (handles type tag prefix correctly)
- LSMVCTreeSearchCursor: Update comparison logic to handle dynamic field counts
- LSMVCTreeDataTupleWriter: Support dynamic tuple format
- LSMVCTreeUtils: Use typeTraits parameter for data frames

This enables proper support for datasets with composite primary keys and INCLUDE field projections in vector indexes.