### PR TITLE
Issue: Vector Index Search Incorrectly Stops After LIMIT Reached on First Partition

### DIFF
--- a/hyracks-fullstack/hyracks/hyracks-storage-am-common/src/main/java/org/apache/hyracks/storage/am/common/dataflow/IndexSearchOperatorNodePushable.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-common/src/main/java/org/apache/hyracks/storage/am/common/dataflow/IndexSearchOperatorNodePushable.java
@@ -290,6 +290,7 @@ public abstract class IndexSearchOperatorNodePushable extends AbstractUnaryInput
                 writeFilterTupleToOutput(((ILSMIndexCursor) cursor).getFilterMinTuple());
                 writeFilterTupleToOutput(((ILSMIndexCursor) cursor).getFilterMaxTuple());
             }
+            /* TODO - vector index search early termination */
             FrameUtils.appendToWriter(writer, appender, tb.getFieldEndOffsets(), tb.getByteArray(), 0, tb.getSize());
             if (outputLimit >= 0 && ++outputCount >= outputLimit) {
                 finished = true;


### PR DESCRIPTION
## Summary

`IndexSearchOperatorNodePushable.searchAllPartitions()` stops searching remaining partitions once `outputLimit` is reached, which produces incorrect results for vector index ANN queries that require global top-K across all partitions.

## Problem

### Current Behavior

In `IndexSearchOperatorNodePushable.java` (lines 464-473):

```java
private void searchAllPartitions(int tupleCount) throws Exception {
    for (int p = 0; p < partitions.length; p++) {
        for (int i = 0; i < tupleCount && !finished; i++) {  // ← exits when finished=true
            resetSearchPredicate(i);
            cursors[p].close();
            indexAccessors[p].search(cursors[p], searchPred);
            writeSearchResults(i, cursors[p]);  // ← sets finished=true when outputCount >= outputLimit
        }
    }
}
```

And in `writeSearchResults()` (lines 293-297):

```java
if (outputLimit >= 0 && ++outputCount >= outputLimit) {
    finished = true;
    break;
}
```

Once `outputLimit` tuples are emitted from ANY partition(s), searching stops entirely. Remaining partitions are never searched.

### Why This Is Wrong for Vector Index

**Query:**
```sql
SELECT row.idx, row.title
FROM Movie row
ORDER BY ann_distance(row.embedding, query_vector, "Euclidean")
LIMIT 10;
```

**Scenario:** 4 storage partitions, LIMIT 10

| Partition | Local Results - distance to the query vector |
|-----------|----------------------------|
| P0 | distances: 5.0, 5.2, 5.5, 6.0, 6.1, 6.3, 7.0, 7.5, 8.0, 8.2, ... |
| P1 | distances: **0.1, 0.3, 0.5, 0.8**, 1.2, 1.5, 2.0, ... |
| P2 | distances: 3.0, 3.2, 3.5, 4.0, ... |
| P3 | distances: **0.2, 0.4, 0.6**, 1.0, 1.1, ... |

**Current (Wrong) Behavior:**
1. Search P0, emit 10 tuples (distances 5.0-8.2)
2. `outputCount = 10 >= outputLimit` → `finished = true`
3. P1, P2, P3 never searched
4. **Result:** 10 tuples with distances 5.0-8.2

**Expected Behavior:**
1. Search ALL partitions, each returns local top-K
2. Merge results from all partitions
3. Apply global LIMIT after merge
4. **Result:** 10 tuples with distances 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.8, 1.0, 1.1, 1.2

### Impact
- **Non-determinism:** Results depend on partition search order
- **Data skew sensitivity:** Worse results when closest vectors are in later partitions

## Proposed Solution

### Option A: Disable Operator-Level LIMIT for Vector Index

For vector index searches, do NOT pass `outputLimit` to the operator. Instead:

1. Push K into `LSMVCTreeSearchCursor` (already implemented)
2. Each partition returns its local top-K
3. Add downstream merge operator to combine results
4. Apply final LIMIT after merge

```java
// In VectorSearchPOperator or MetadataProvider
// Don't set outputLimit for vector index search
long outputLimit = -1;  // Disable operator-level limit
```

### Option B: Vector-Specific Operator (Recommended)

Create `VectorSearchOperatorNodePushable` that:
1. Does NOT inherit the problematic LIMIT logic
2. Always searches all partitions
3. Each partition returns local top-K via cursor
4. Merges results locally before emitting (or emits all for downstream merge)

```java
public class VectorSearchOperatorNodePushable extends AbstractUnaryInputUnaryOutputOperatorNodePushable {

    private void searchAllPartitions(int tupleCount) throws Exception {
        // Collect results from ALL partitions
        PriorityQueue<Result> globalTopK = new PriorityQueue<>(K, distanceComparator);

        for (int p = 0; p < partitions.length; p++) {
            for (int i = 0; i < tupleCount; i++) {
                resetSearchPredicate(i);
                cursors[p].close();
                indexAccessors[p].search(cursors[p], searchPred);

                // Collect into global heap (no early termination!)
                collectResults(cursors[p], globalTopK);
            }
        }

        // Emit global top-K
        emitTopK(globalTopK);
    }
}
```

## Files Affected

- `hyracks-storage-am-common/.../dataflow/IndexSearchOperatorNodePushable.java` - Root cause

## Test Case

```sql
-- Setup: Create dataset with vectors distributed across partitions
-- Ensure closest vectors are NOT in partition 0

CREATE DATASET TestVectors(id: int, embedding: [float]) PRIMARY KEY id;
-- Insert data such that:
--   Partition 0: vectors far from query (distance > 5.0)
--   Partition 1: vectors close to query (distance < 1.0)

-- Query
SELECT id
FROM TestVectors
ORDER BY ann_distance(embedding, [1.0, 2.0, 3.0], "Euclidean")
LIMIT 5;

-- Expected: Results from Partition 1 (closest vectors)
-- Actual (bug): Results from Partition 0 (not closest)
```

## Related

- Vector index filtered search implementation (cursor-level filtering)
- Multi-cluster probing in `LSMVCTreeSearchCursor`
- Global top-K merge across partitions

## Priority

**High** - This is a correctness bug that affects all vector index ANN queries on partitioned datasets.