### PR TITLE
Resolve grammar conflict between INCLUDE UNKNOWN KEY (for B-tree indexes) and INCLUDE (fields) (for vector indexes) using enhanced lookahead

### DIFF
--- a/asterixdb/asterix-lang-sqlpp/src/main/javacc/SQLPP.jj
+++ b/asterixdb/asterix-lang-sqlpp/src/main/javacc/SQLPP.jj
@@ -1438,7 +1438,9 @@ CreateIndexStatement IndexSpecification(Token startStmtToken, boolean isVectorIn
       )*
     <RIGHTPAREN>
     ( <TYPE> indexParams = IndexType() )? ( <ENFORCED> { enforced = true; } )?
-    ( LOOKAHEAD({laIdentifier(EXCLUDE) || laIdentifier(INCLUDE)}) <IDENTIFIER>
+    // Parse INCLUDE/EXCLUDE UNKNOWN KEY (for non-vector indexes)
+    // Lookahead checks that INCLUDE/EXCLUDE is followed by UNKNOWN to disambiguate from INCLUDE (fields)
+    ( LOOKAHEAD({(laIdentifier(EXCLUDE) || laIdentifier(INCLUDE)) && laToken(2, UNKNOWN)}) <IDENTIFIER>
     {
       if (isToken(EXCLUDE)) {
         excludeUnknown = true;
@@ -1455,6 +1457,27 @@ CreateIndexStatement IndexSpecification(Token startStmtToken, boolean isVectorIn
         castConfig = castConfigDefaultNull.first;
         castDefaultNull = castConfigDefaultNull.second;
       }
+    )?
+
+    // Parse INCLUDE clause for vector index additional fields (e.g., INCLUDE (year, title))
+    // Lookahead checks that INCLUDE is followed by LEFTPAREN to disambiguate from INCLUDE UNKNOWN KEY
+    // This allows filtering on these fields during vector search
+    ( LOOKAHEAD({laIdentifier(INCLUDE) && laToken(2, LEFTPAREN)}) <IDENTIFIER>
+      {
+        if (!isToken(INCLUDE)) {
+          throw createUnexpectedTokenError();
+        }
+      }
+      <LEFTPAREN> { startElementToken = token; }
+        indexedElement = IndexedElement(startElementToken) {
+          nonVectorFieldsList.add(indexedElement);
+        }
+        (<COMMA> { startElementToken = token; }
+          indexedElement = IndexedElement(startElementToken) {
+            nonVectorFieldsList.add(indexedElement);
+          }
+        )*
+      <RIGHTPAREN>
     )?
 
     // Parse WITH clause for vector index configuration

--- a/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/entitytupletranslators/IndexTupleTranslator.java
+++ b/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/entitytupletranslators/IndexTupleTranslator.java
@@ -93,6 +93,7 @@ public class IndexTupleTranslator extends AbstractTupleTranslator<Index> {
     // Field name of open field.
     public static final String GRAM_LENGTH_FIELD_NAME = "GramLength";
     public static final String FULL_TEXT_CONFIG_FIELD_NAME = "FullTextConfig";
+    public static final String INCLUDE_FIELDS_FIELD_NAME = "IncludeFields";
     public static final String INDEX_SEARCHKEY_TYPE_FIELD_NAME = "SearchKeyType";
     public static final String INDEX_ISENFORCED_FIELD_NAME = "IsEnforced";
     public static final String INDEX_EXCLUDE_UNKNOWN_FIELD_NAME = "ExcludeUnknownKey";
@@ -472,7 +473,20 @@ public class IndexTupleTranslator extends AbstractTupleTranslator<Index> {
                 excludeUnknownKey = OptionalBoolean.empty();
                 castDefaultNull = OptionalBoolean.empty();
                 AdmObjectNode withObjectNode = readWithProperties(indexRecord);
-                indexDetails = new Index.VectorIndexDetails(keyFieldNames.getFirst(), keyFieldNames,
+
+                // Read include_fields from metadata
+                List<List<String>> includeFieldNames = new ArrayList<>();
+                int includeFieldsPos = indexRecord.getType().getFieldIndex(INCLUDE_FIELDS_FIELD_NAME);
+                if (includeFieldsPos >= 0) {
+                    IACursor cursor =
+                            ((AOrderedList) indexRecord.getValueByPos(includeFieldsPos)).getCursor();
+                    while (cursor.next()) {
+                        String fieldName = ((AString) cursor.get()).getStringValue();
+                        includeFieldNames.add(Collections.singletonList(fieldName));
+                    }
+                }
+
+                indexDetails = new Index.VectorIndexDetails(keyFieldNames.getFirst(), includeFieldNames,
                         keyFieldSourceIndicator, keyFieldTypes, isOverridingKeyTypes, excludeUnknownKey,
                         castDefaultNull, null, null, null, withObjectNode);
                 break;
@@ -948,7 +962,7 @@ public class IndexTupleTranslator extends AbstractTupleTranslator<Index> {
         fieldValue.reset();
         listBuilder.write(fieldValue.getDataOutput(), true);
         nameValue.reset();
-        aString.setValue("include_fields");
+        aString.setValue(INCLUDE_FIELDS_FIELD_NAME);
         stringSerde.serialize(aString, nameValue.getDataOutput());
         recordBuilder.addField(nameValue, fieldValue);
     }


### PR DESCRIPTION
Resolve grammar conflict between INCLUDE UNKNOWN KEY (for B-tree indexes) and INCLUDE (fields) (for vector indexes) using enhanced lookahead:

- INCLUDE followed by UNKNOWN -> INCLUDE UNKNOWN KEY
- INCLUDE followed by ( -> INCLUDE (field list) for vector index

Also fix IndexTupleTranslator to properly read INCLUDE_FIELDS from metadata when deserializing vector index details.