### PR TITLE
Unify triangle inequality pruning to use all-quantized distances

### DIFF
--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/VCTreeDataTupleConstants.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/VCTreeDataTupleConstants.java
@@ -28,7 +28,7 @@ package org.apache.hyracks.storage.am.vector;
  *   | distance(0) | centroidId(1) | PK...(2+) | includes...(N+) |
  *
  * Quantized format (description != null):
- *   | distance(0) | quantized_distance(1) | quantized_embedding(2) | centroidId(3) | PK...(4+) | includes...(N+) |
+ *   | distance(0) | centroidId(1) | quantized_distance(2) | quantized_embedding(3) | PK...(4+) | includes...(N+) |
  */
 public final class VCTreeDataTupleConstants {
 
@@ -50,15 +50,17 @@ public final class VCTreeDataTupleConstants {
     public static final int NQ_NUM_SECONDARY_FIELDS = 2;
 
     // --- Quantized format field offsets (description != null) ---
-
-    /** Quantized distance field index in quantized format. */
-    public static final int Q_QUANTIZED_DISTANCE_FIELD = 1;
-
-    /** Quantized embedding field index in quantized format. */
-    public static final int Q_QUANTIZED_EMBEDDING_FIELD = 2;
+    // Layout: [distance(0), centroidId(1), quantized_distance(2), quantized_embedding(3), PK...(4+)]
+    // This matches createTransformedTuple() in VCTreeBulkLoaderAndGroupingOperatorDescriptor.
 
     /** Centroid ID field index in quantized format. */
-    public static final int Q_CENTROID_ID_FIELD = 3;
+    public static final int Q_CENTROID_ID_FIELD = 1;
+
+    /** Quantized distance field index in quantized format. */
+    public static final int Q_QUANTIZED_DISTANCE_FIELD = 2;
+
+    /** Quantized embedding field index in quantized format. */
+    public static final int Q_QUANTIZED_EMBEDDING_FIELD = 3;
 
     /** First primary key field index in quantized format. */
     public static final int Q_PK_START_FIELD = 4;

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/utils/VCTreeNavigationUtils.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/utils/VCTreeNavigationUtils.java
@@ -692,20 +692,27 @@ public class VCTreeNavigationUtils {
         public final int pageId;
         public final double[] centroid;
         public final long directoryPageId; // Direct pointer to cluster's directory page
+        public final double quantizedDistance; // D(q̃, C̃) — NaN if not computed
 
         public LeafCentroid(int centroidId, double distance, int tupleIndex, int pageId, double[] centroid,
-                long directoryPageId) {
+                long directoryPageId, double quantizedDistance) {
             this.centroidId = centroidId;
             this.distance = distance;
             this.tupleIndex = tupleIndex;
             this.pageId = pageId;
             this.centroid = centroid;
             this.directoryPageId = directoryPageId;
+            this.quantizedDistance = quantizedDistance;
+        }
+
+        public LeafCentroid(int centroidId, double distance, int tupleIndex, int pageId, double[] centroid,
+                long directoryPageId) {
+            this(centroidId, distance, tupleIndex, pageId, centroid, directoryPageId, Double.NaN);
         }
 
         // Legacy constructor for backwards compatibility
         public LeafCentroid(int centroidId, double distance, int tupleIndex, int pageId, double[] centroid) {
-            this(centroidId, distance, tupleIndex, pageId, centroid, -1);
+            this(centroidId, distance, tupleIndex, pageId, centroid, -1, Double.NaN);
         }
     }
 
@@ -1294,6 +1301,22 @@ public class VCTreeNavigationUtils {
             int rootPageId, ITreeIndexFrameFactory interiorFrameFactory, ITreeIndexFrameFactory leafFrameFactory,
             double[] queryVector, IVectorDistanceFunction distanceFunction, double epsilon)
             throws HyracksDataException {
+        return findCloseCentroidsLevelWiseGlobalSort(bufferCache, fileId, rootPageId, interiorFrameFactory,
+                leafFrameFactory, queryVector, distanceFunction, epsilon, null, null);
+    }
+
+    /**
+     * Overload that accepts quantizer parameters for computing quantized D(q,C).
+     * Navigation still uses full-precision distances; quantizedDistance is extra metadata
+     * populated in each ClusterSearchResult for triangle inequality pruning at the cursor level.
+     *
+     * @param quantizedQueryVector Dequantized form of query vector (nullable)
+     * @param quantizer Quantizer for dequantizing leaf centroid bytes (nullable)
+     */
+    public static List<ClusterSearchResult> findCloseCentroidsLevelWiseGlobalSort(IBufferCache bufferCache, int fileId,
+            int rootPageId, ITreeIndexFrameFactory interiorFrameFactory, ITreeIndexFrameFactory leafFrameFactory,
+            double[] queryVector, IVectorDistanceFunction distanceFunction, double epsilon,
+            double[] quantizedQueryVector, IVectorQuantizer quantizer) throws HyracksDataException {
 
         List<ClusterSearchResult> allCentroids = new ArrayList<>();
         Set<Integer> visitedLeafPages = new HashSet<>();
@@ -1327,7 +1350,8 @@ public class VCTreeNavigationUtils {
                         }
 
                         LeafCollectionStats stats = collectLeafCentroidsForLevelWise(bufferCache, fileId, queryVector,
-                                node.pageId, leafFrame, leafFrameFactory, distanceFunction);
+                                node.pageId, leafFrame, leafFrameFactory, distanceFunction, quantizedQueryVector,
+                                quantizer);
 
                         if (stats.centroids.isEmpty()) {
                             continue;
@@ -1335,9 +1359,9 @@ public class VCTreeNavigationUtils {
 
                         // Add ALL centroids from this leaf page to global collection
                         for (LeafCentroid centroid : stats.centroids) {
-                            allCentroids.add(
-                                    ClusterSearchResult.create(centroid.pageId, centroid.tupleIndex, centroid.centroid,
-                                            centroid.distance, centroid.centroidId, centroid.directoryPageId));
+                            allCentroids.add(ClusterSearchResult.create(centroid.pageId, centroid.tupleIndex,
+                                    centroid.centroid, centroid.distance, centroid.centroidId,
+                                    centroid.directoryPageId, centroid.quantizedDistance));
                         }
 
                     } else {
@@ -1408,6 +1432,18 @@ public class VCTreeNavigationUtils {
             double[] queryVector, int startPageId, IVectorClusteringLeafFrame initialLeafFrame,
             ITreeIndexFrameFactory leafFrameFactory, IVectorDistanceFunction distanceFunction)
             throws HyracksDataException {
+        return collectLeafCentroidsForLevelWise(bufferCache, fileId, queryVector, startPageId, initialLeafFrame,
+                leafFrameFactory, distanceFunction, null, null);
+    }
+
+    /**
+     * Collect all centroids from a leaf page and its overflow chain for level-wise traversal.
+     * When quantizer is provided, also computes quantized D(q,C) for each centroid.
+     */
+    private static LeafCollectionStats collectLeafCentroidsForLevelWise(IBufferCache bufferCache, int fileId,
+            double[] queryVector, int startPageId, IVectorClusteringLeafFrame initialLeafFrame,
+            ITreeIndexFrameFactory leafFrameFactory, IVectorDistanceFunction distanceFunction,
+            double[] quantizedQueryVector, IVectorQuantizer quantizer) throws HyracksDataException {
 
         List<LeafCentroid> centroids = new ArrayList<>();
         int currentPageId = startPageId;
@@ -1446,8 +1482,19 @@ public class VCTreeNavigationUtils {
                         double distance = distanceFunction.apply(queryVector, centroid);
                         candidatesProcessed++;
 
+                        // Compute quantized distance if quantizer is available
+                        double quantizedDistance = Double.NaN;
+                        if (quantizer != null && quantizedQueryVector != null) {
+                            byte[] quantizedCentroidBytes = currentFrame.getQuantizedCentroidBytes(i);
+                            if (quantizedCentroidBytes != null) {
+                                double[] dequantizedCentroid = quantizer.dequantize(quantizedCentroidBytes);
+                                quantizedDistance =
+                                        distanceFunction.apply(quantizedQueryVector, dequantizedCentroid);
+                            }
+                        }
+
                         centroids.add(new LeafCentroid(centroidId, distance, i, currentPageId, centroid.clone(),
-                                directoryPageId));
+                                directoryPageId, quantizedDistance));
                     } catch (Exception e) {
                         // Skip malformed tuples
                         continue;

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/IClusterSelectionStrategy.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/IClusterSelectionStrategy.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.apache.hyracks.api.exceptions.HyracksDataException;
 import org.apache.hyracks.storage.am.vector.api.IVectorDistanceFunction;
+import org.apache.hyracks.storage.am.vector.api.IVectorQuantizer;
 import org.apache.hyracks.storage.am.vector.impls.ClusterSearchResult;
 import org.apache.hyracks.storage.am.vector.impls.VectorClusteringSearchCursor;
 import org.apache.hyracks.storage.am.vector.impls.VectorClusteringTree;
@@ -98,6 +99,18 @@ public interface IClusterSelectionStrategy {
      * @return The first cluster to explore, or null if not yet computed
      */
     ClusterSearchResult getFirstCluster();
+
+    /**
+     * Set quantizer state for computing quantized D(q,C) in ClusterSearchResult.
+     * Call before initialize() so that level-wise navigation can populate
+     * ClusterSearchResult.quantizedDistance for each leaf centroid found.
+     *
+     * @param quantizedQueryVector Dequantized form of query vector (nullable — pass null to skip)
+     * @param quantizer Quantizer for dequantizing leaf centroid bytes (nullable — pass null to skip)
+     */
+    default void setQuantizer(double[] quantizedQueryVector, IVectorQuantizer quantizer) {
+        // Default no-op for strategies that don't support quantized distance
+    }
 
     /**
      * Reset the strategy for a new search.

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeBlockedCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeBlockedCursor.java
@@ -227,6 +227,12 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
                         .create(new IllegalArgumentException("Query vector must be provided for optimized search"));
             }
 
+            // Set quantizer on strategy before initialize() so level-wise navigation
+            // can compute quantized D(q,C) for each leaf centroid in ClusterSearchResult
+            if (quantizedQueryVector != null && quantizer != null) {
+                clusterStrategy.setQuantizer(quantizedQueryVector, quantizer);
+            }
+
             // Initialize cluster selection strategy with first component's tree
             clusterStrategy.initialize(vcTree, queryVector, distanceFunction, K);
 
@@ -247,13 +253,19 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
             return;
         }
 
-        // D(q, C) is the distance from query to closest centroid
-        this.dqc = firstCluster.distance;
+        // D(q, C) — use quantized distance when available to keep all three
+        // triangle inequality distances in the same (quantized) metric space
+        if (quantizer != null && firstCluster.hasQuantizedDistance()) {
+            this.dqc = firstCluster.quantizedDistance;
+        } else {
+            this.dqc = firstCluster.distance;
+        }
 
         System.err.println(String.format(
-                "[LSMVCTreeBlockedCursor] First cluster from strategy: centroidId=%d, D(q,C)=%.4f, directoryPageId=%d, level-wise count=%d",
-                firstCluster.centroidId, dqc, firstCluster.directoryPageId,
-                clusterStrategy.getLevelWiseClusterCount()));
+                "[LSMVCTreeBlockedCursor] First cluster: cid=%d, D(q,C)_full=%.4f, D(q,C)_quant=%.4f, dqc_used=%.4f, dirPage=%d, levelWise=%d",
+                firstCluster.centroidId, firstCluster.distance,
+                firstCluster.hasQuantizedDistance() ? firstCluster.quantizedDistance : Double.NaN, dqc,
+                firstCluster.directoryPageId, clusterStrategy.getLevelWiseClusterCount()));
 
         // Perform the bidirectional search on first cluster
         openClusterAndSearch(firstCluster, queryVector, dqc);
@@ -282,8 +294,10 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
             }
 
             System.err.println(String.format(
-                    "[LSMVCTreeBlockedCursor] Advancing to cluster: centroidId=%d, D(q,C)=%.4f, directoryPageId=%d",
-                    nextCluster.centroidId, nextCluster.distance, nextCluster.directoryPageId));
+                    "[LSMVCTreeBlockedCursor] Advancing to cluster: cid=%d, D(q,C)_full=%.4f, D(q,C)_quant=%.4f, dqc_used=%.4f, dirPage=%d",
+                    nextCluster.centroidId, nextCluster.distance,
+                    nextCluster.hasQuantizedDistance() ? nextCluster.quantizedDistance : Double.NaN, dqc,
+                    nextCluster.directoryPageId));
 
             advanceAllComponentsToNextCluster(nextCluster);
             clustersExplored++;
@@ -315,9 +329,10 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
         leftCtx.reset();
         topKWindow.clear();
 
-        // Open all VCB cursors for this cluster
+        // Open all VCB cursors for this cluster.
+        // Use full-precision distance for pivot positioning (data pages sorted by full-precision D(x,C)).
         for (int i = 0; i < numComponents; i++) {
-            vcbCursors[i].openCluster(cluster.directoryPageId, dqc);
+            vcbCursors[i].openCluster(cluster.directoryPageId, cluster.distance);
         }
 
         // Seed the priority queues
@@ -337,8 +352,12 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
      * results from previous clusters contribute to the termination threshold.
      */
     private void advanceAllComponentsToNextCluster(ClusterSearchResult cluster) throws HyracksDataException {
-        // Update D(q, C) for the new cluster's centroid
-        this.dqc = cluster.distance;
+        // Update D(q, C) for the new cluster's centroid — use quantized distance when available
+        if (quantizer != null && cluster.hasQuantizedDistance()) {
+            this.dqc = cluster.quantizedDistance;
+        } else {
+            this.dqc = cluster.distance;
+        }
 
         // TODO: Quantize the query vector per-cluster here. The centroid is available from cluster.centroid,
         // which can be used to compute the residual (queryVector - centroid) for product quantization.
@@ -347,9 +366,10 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
         rightCtx.reset();
         leftCtx.reset();
 
-        // Open all VCB cursors for this cluster (same cluster for all components)
+        // Open all VCB cursors for this cluster (same cluster for all components).
+        // Use full-precision distance for pivot positioning (data pages sorted by full-precision D(x,C)).
         for (int i = 0; i < numComponents; i++) {
-            vcbCursors[i].openCluster(cluster.directoryPageId, dqc);
+            vcbCursors[i].openCluster(cluster.directoryPageId, cluster.distance);
         }
 
         // Seed the priority queues
@@ -423,15 +443,32 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
      * Perform bidirectional search with triangle inequality termination.
      */
     private void performBidirectionalSearch() throws HyracksDataException {
+        int iterCount = 0;
         while (!rightCtx.terminated || !leftCtx.terminated) {
             // Process right direction
             if (!rightCtx.terminated) {
                 ITupleReference rightTuple = getNextValidTuple(rightCtx);
                 if (rightTuple != null) {
+                    double dxcFull = extractFullPrecisionDxc(rightTuple);
+                    double dxcQuant = (quantizer != null) ? extractDistanceToCentroid(rightTuple) : Double.NaN;
+                    double dqx = Double.NaN;
+
                     // Apply INCLUDE field filter before adding to top-K window
                     if (passesTupleFilter(rightTuple)) {
-                        double dqx = computeApproximateDistance(rightTuple);
+                        dqx = computeApproximateDistance(rightTuple);
                         addToTopKWindow(rightTuple, dqx);
+                    }
+
+                    // Log first few + every 10th tuple (include threshold when topK is full)
+                    if (true) {
+                        double kthDqx = topKWindow.isEmpty() ? Double.NaN : topKWindow.peek().dqx;
+                        double rThresh = kthDqx + dqc;
+                        double nextRightDxc =
+                                rightCtx.queue.isEmpty() ? Double.NaN : rightCtx.queue.peek().dxc;
+                        System.err.println(String.format(
+                                "[bidir] RIGHT #%d: D(x,C)_full=%.4f, D(x,C)_quant=%.4f, D(q,x)_quant=%.4f, D(q,C)_used=%.4f, topK=%d, kth_dqx=%.4f, threshold=%.4f, nextDxc=%.4f",
+                                iterCount, dxcFull, dxcQuant, dqx, dqc, topKWindow.size(), kthDqx, rThresh,
+                                nextRightDxc));
                     }
 
                     // Check right termination: D(x',C) > max{D(q,x)} + D(q,C)
@@ -441,12 +478,13 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
                         if (nextDxc > threshold) {
                             rightCtx.terminated = true;
                             System.err.println(String.format(
-                                    "[LSMVCTreeBlockedCursor] Right terminated: nextDxc=%.4f > threshold=%.4f", nextDxc,
-                                    threshold));
+                                    "[bidir] Right TERMINATED: nextDxc=%.4f > threshold=%.4f (kth_dqx=%.4f + dqc=%.4f)",
+                                    nextDxc, threshold, topKWindow.peek().dqx, dqc));
                         }
                     }
                 } else {
                     rightCtx.terminated = true;
+                    System.err.println("[bidir] Right EXHAUSTED");
                 }
             }
 
@@ -454,10 +492,26 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
             if (!leftCtx.terminated) {
                 ITupleReference leftTuple = getNextValidTuple(leftCtx);
                 if (leftTuple != null) {
+                    double dxcFull = extractFullPrecisionDxc(leftTuple);
+                    double dxcQuant = (quantizer != null) ? extractDistanceToCentroid(leftTuple) : Double.NaN;
+                    double dqx = Double.NaN;
+
                     // Apply INCLUDE field filter before adding to top-K window
                     if (passesTupleFilter(leftTuple)) {
-                        double dqx = computeApproximateDistance(leftTuple);
+                        dqx = computeApproximateDistance(leftTuple);
                         addToTopKWindow(leftTuple, dqx);
+                    }
+
+                    // Log first few + every 10th tuple (include threshold when topK is full)
+                    if (true) {
+                        double kthDqx = topKWindow.isEmpty() ? Double.NaN : topKWindow.peek().dqx;
+                        double lThresh = dqc - kthDqx;
+                        double nextLeftDxc =
+                                leftCtx.queue.isEmpty() ? Double.NaN : leftCtx.queue.peek().dxc;
+                        System.err.println(String.format(
+                                "[bidir] LEFT  #%d: D(x,C)_full=%.4f, D(x,C)_quant=%.4f, D(q,x)_quant=%.4f, D(q,C)_used=%.4f, topK=%d, kth_dqx=%.4f, threshold=%.4f, nextDxc=%.4f",
+                                iterCount, dxcFull, dxcQuant, dqx, dqc, topKWindow.size(), kthDqx, lThresh,
+                                nextLeftDxc));
                     }
 
                     // Check left termination: D(x',C) < D(q,C) - max{D(q,x)}
@@ -467,14 +521,16 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
                         if (nextDxc < threshold) {
                             leftCtx.terminated = true;
                             System.err.println(String.format(
-                                    "[LSMVCTreeBlockedCursor] Left terminated: nextDxc=%.4f < threshold=%.4f", nextDxc,
-                                    threshold));
+                                    "[bidir] Left TERMINATED: nextDxc=%.4f < threshold=%.4f (dqc=%.4f - kth_dqx=%.4f)",
+                                    nextDxc, threshold, dqc, topKWindow.peek().dqx));
                         }
                     }
                 } else {
                     leftCtx.terminated = true;
+                    System.err.println("[bidir] Left EXHAUSTED");
                 }
             }
+            iterCount++;
         }
 
         System.err.println(
@@ -760,9 +816,22 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
     }
 
     /**
-     * Extract D(x, C) from tuple. First field is distance_to_centroid.
+     * Extract D(x, C) from tuple.
+     * When quantizer is available, reads field 2 (Q_QUANTIZED_DISTANCE_FIELD = quantized D(x,C))
+     * to keep all three triangle inequality distances in the same (quantized) metric space.
+     * Otherwise reads field 0 (full-precision D(x,C)).
      */
     private double extractDistanceToCentroid(ITupleReference tuple) {
+        int fieldIndex = (quantizer != null) ? 2 : 0; // field 2 = D(x,C)_quant, field 0 = D(x,C)_full
+        byte[] data = tuple.getFieldData(fieldIndex);
+        int offset = tuple.getFieldStart(fieldIndex);
+        return DoublePointable.getDouble(data, offset);
+    }
+
+    /**
+     * Always extract field 0 (full-precision D(x,C)) for diagnostic logging.
+     */
+    private double extractFullPrecisionDxc(ITupleReference tuple) {
         byte[] data = tuple.getFieldData(0);
         int offset = tuple.getFieldStart(0);
         return DoublePointable.getDouble(data, offset);
@@ -781,9 +850,9 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
     private double computeApproximateDistance(ITupleReference tuple) throws HyracksDataException {
         // When quantized, compute the approximate distance from the quantized representations
         if (quantizedQueryVector != null && quantizer != null) {
-            // Read quantized bytes from field 2 (Q_QUANTIZED_EMBEDDING_FIELD)
+            // Read quantized bytes from field 3 (Q_QUANTIZED_EMBEDDING_FIELD)
             // Field is serialized by ByteArraySerializerDeserializer with a VarLen length prefix
-            int vectorFieldIndex = 2;
+            int vectorFieldIndex = 3;
             byte[] data = tuple.getFieldData(vectorFieldIndex);
             int offset = tuple.getFieldStart(vectorFieldIndex);
             int contentLength = ByteArrayPointable.getContentLength(data, offset);

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/NprobeClusterSelectionStrategy.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/NprobeClusterSelectionStrategy.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.apache.hyracks.api.exceptions.HyracksDataException;
 import org.apache.hyracks.storage.am.vector.api.IVectorDistanceFunction;
+import org.apache.hyracks.storage.am.vector.api.IVectorQuantizer;
 import org.apache.hyracks.storage.am.vector.impls.ClusterSearchResult;
 import org.apache.hyracks.storage.am.vector.impls.VectorClusteringSearchCursor;
 import org.apache.hyracks.storage.am.vector.impls.VectorClusteringTree;
@@ -54,6 +55,10 @@ public class NprobeClusterSelectionStrategy implements IClusterSelectionStrategy
     // Shared state for cross-component deduplication
     private Set<Integer> visitedCentroidIds;
 
+    // Quantizer state for computing quantized D(q,C) in ClusterSearchResult
+    private double[] quantizedQueryVector;
+    private IVectorQuantizer quantizer;
+
     // For DFS fallback
     private VectorClusteringSearchCursor firstCursor;
 
@@ -61,6 +66,12 @@ public class NprobeClusterSelectionStrategy implements IClusterSelectionStrategy
         this.nprobe = nprobe;
         this.epsilon = epsilon;
         this.visitedCentroidIds = new HashSet<>();
+    }
+
+    @Override
+    public void setQuantizer(double[] quantizedQueryVector, IVectorQuantizer quantizer) {
+        this.quantizedQueryVector = quantizedQueryVector;
+        this.quantizer = quantizer;
     }
 
     @Override
@@ -75,7 +86,8 @@ public class NprobeClusterSelectionStrategy implements IClusterSelectionStrategy
             try {
                 globalLevelWiseClusters = VCTreeNavigationUtils.findCloseCentroidsLevelWiseGlobalSort(
                         vcTree.getBufferCache(), vcTree.getFileId(), vcTree.getRootPageId(),
-                        vcTree.getInteriorFrameFactory(), vcTree.getLeafFrameFactory(), queryVector, distFunc, epsilon);
+                        vcTree.getInteriorFrameFactory(), vcTree.getLeafFrameFactory(), queryVector, distFunc, epsilon,
+                        quantizedQueryVector, quantizer);
 
                 // Mark first cluster as visited and start getNextCluster() from index 1
                 // The cursor handles index 0 separately via getFirstCluster()
@@ -186,6 +198,8 @@ public class NprobeClusterSelectionStrategy implements IClusterSelectionStrategy
         this.levelWisePhaseComplete = false;
         this.visitedCentroidIds.clear();
         this.firstCursor = null;
+        this.quantizedQueryVector = null;
+        this.quantizer = null;
     }
 
     @Override


### PR DESCRIPTION
When a quantizer is present, all three distances in the triangle inequality (D(q,C), D(x,C), D(q,x)) must be in the same metric space to avoid incorrect pruning. Previously D(x,C) and D(q,C) were full-precision while D(q,x) was quantized, violating this requirement.

Key fixes:
- Fix VCTreeDataTupleConstants field indices to match actual tuple layout from createTransformedTuple(): centroidId=1, quantized_distance=2, quantized_embedding=3
- Fix computeApproximateDistance() to read quantized embedding from field 3 instead of field 2
- Read quantized D(x,C) from field 2 when quantizer is available
- Thread quantizer through IClusterSelectionStrategy and VCTreeNavigationUtils to compute quantized D(q,C) at query time
- Use full-precision D(q,C) for pivot positioning (data pages are sorted by full-precision D(x,C)), quantized D(q,C) only for termination thresholds
- Add per-tuple diagnostic logging for bidirectional search