### PR TITLE
Support NULL/MISSING values in vector index INCLUDE fields

### DIFF
--- a/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/optimizer/rules/PushFilterIntoVectorSearchRule.java
+++ b/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/optimizer/rules/PushFilterIntoVectorSearchRule.java
@@ -32,6 +32,7 @@ import org.apache.asterix.metadata.entities.Index;
 import org.apache.asterix.object.base.AdmObjectNode;
 import org.apache.asterix.om.functions.BuiltinFunctions;
 import org.apache.asterix.om.types.ARecordType;
+import org.apache.asterix.om.types.BuiltinType;
 import org.apache.asterix.om.types.IAType;
 import org.apache.asterix.optimizer.rules.am.AccessMethodJobGenParams;
 import org.apache.asterix.optimizer.rules.am.AccessMethodUtils;
@@ -213,7 +214,12 @@ public class PushFilterIntoVectorSearchRule implements IAlgebraicRewriteRule {
                 filterVarToFieldIndex.put(newVar, includeFieldPhysicalIndex);
 
                 // Store type for filter compilation
+                // For open-schema fields not in the type declaration, getSubFieldType returns null.
+                // Default to ANY so the type environment can resolve the variable type.
                 IAType fieldType = searchInfo.recordType.getSubFieldType(fieldPath);
+                if (fieldType == null) {
+                    fieldType = BuiltinType.ANY;
+                }
                 filterVarToType.put(newVar, fieldType);
 
                 System.err.println("=== Created " + newVar + " for field '" + fieldName + "' -> physical field "

--- a/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/translator/util/ValidateUtil.java
+++ b/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/translator/util/ValidateUtil.java
@@ -279,8 +279,8 @@ public class ValidateUtil {
                     case DAYTIMEDURATION:
                         break;
                     case ANY:
-                        if (indexType == IndexType.BTREE) {
-                            // ANY is only allowed for normal secondary indexes
+                        if (indexType == IndexType.BTREE || indexType == IndexType.VECTOR) {
+                            // ANY is allowed for BTREE and VECTOR (include fields) indexes
                             break;
                         }
                     default:

--- a/asterixdb/asterix-app/src/main/java/org/apache/asterix/app/translator/QueryTranslator.java
+++ b/asterixdb/asterix-app/src/main/java/org/apache/asterix/app/translator/QueryTranslator.java
@@ -1593,7 +1593,7 @@ public class QueryTranslator extends AbstractLangTranslator implements IStatemen
                     }
 
                     if (fieldTypePrime == null) {
-                        if (indexType != IndexType.BTREE) {
+                        if (indexType != IndexType.BTREE && indexType != IndexType.VECTOR) {
                             if (projectPath != null) {
                                 String fieldName =
                                         LogRedactionUtil.userData(RecordUtil.toFullyQualifiedName(projectPath));

--- a/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/utils/SecondaryVectorOperationsHelper.java
+++ b/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/utils/SecondaryVectorOperationsHelper.java
@@ -37,6 +37,7 @@ import org.apache.asterix.metadata.declared.MetadataProvider;
 import org.apache.asterix.metadata.entities.Dataset;
 import org.apache.asterix.metadata.entities.Index;
 import org.apache.asterix.metadata.entities.InternalDatasetDetails;
+import org.apache.asterix.metadata.utils.KeyFieldTypeUtil;
 import org.apache.asterix.object.base.AdmObjectNode;
 import org.apache.asterix.om.pointables.base.DefaultOpenFieldType;
 import org.apache.asterix.om.types.AOrderedListType;
@@ -1135,10 +1136,15 @@ public class SecondaryVectorOperationsHelper extends SecondaryTreeIndexOperation
                 secondaryFieldAccessEvalFactories[fieldIndex] =
                         createFieldCast(secFieldAccessor, isOverridingKeyFieldTypes, enforcedType, sourceType, keyType);
                 anySecondaryKeyIsNullable = anySecondaryKeyIsNullable || keyTypePair.second;
-                secondaryRecFields[fieldIndex] = serdeProvider.getSerializerDeserializer(keyType);
+                // For nullable/missable include fields, use a NULL-safe serializer.
+                // Unlike B-tree which filters out NULL records, vector INCLUDE fields preserve NULLs.
+                IAType serdeType = keyTypePair.second
+                        ? KeyFieldTypeUtil.makeUnknownableType(keyType, true, true)
+                        : keyType;
+                secondaryRecFields[fieldIndex] = serdeProvider.getSerializerDeserializer(serdeType);
                 secondaryComparatorFactories[fieldIndex] =
                         comparatorFactoryProvider.getBinaryComparatorFactory(keyType, true);
-                secondaryTypeTraits[fieldIndex] = typeTraitProvider.getTypeTrait(keyType);
+                secondaryTypeTraits[fieldIndex] = typeTraitProvider.getTypeTrait(serdeType);
                 secondaryBloomFilterKeyFields[fieldIndex] = fieldIndex;
             }
         }


### PR DESCRIPTION
Allow vector indexes to have INCLUDE fields from open-schema records where the field type is not declared in the dataset type. Previously, this would fail with "cannot find type of field" (ASX1079).

Changes:
- QueryTranslator: Allow VECTOR indexes to use ANY type for unresolved INCLUDE fields (was BTREE-only)
- ValidateUtil: Allow ANY type validation for VECTOR index fields
- SecondaryVectorOperationsHelper: Use NULL-safe serializer for nullable INCLUDE fields so ANull/AMissing can be serialized correctly
- PushFilterIntoVectorSearchRule: Default to BuiltinType.ANY when field type is not in the schema, preventing NPE during filter compilation