### PR TITLE
Fix stale overflow flag causing duplicate cluster traversal in level-wise search

### DIFF
--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VCTreeStaticStructureBuilder.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VCTreeStaticStructureBuilder.java
@@ -393,7 +393,7 @@ public class VCTreeStaticStructureBuilder extends AbstractTreeIndexBulkLoader {
                 if (currentLevel == numLevels - 1 && currentPage != null) {
                     int nextClusterPageId = computeCurrentClusterPageId();
                     leafFrame.setNextLeaf(nextClusterPageId);
-                    // Keep overflow flag as-is (only true if this page had within-cluster overflow)
+                    leafFrame.setOverflowFlagBit(false);
                     LOGGER.debug("Linking leaf page to next cluster: current page -> page {}", nextClusterPageId);
                 }
 

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/utils/VCTreeNavigationUtils.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/utils/VCTreeNavigationUtils.java
@@ -956,17 +956,18 @@ public class VCTreeNavigationUtils {
 
                     // Skip if already visited (e.g., by level-wise exploration)
                     if (state.isVisited(next.centroidId)) {
-                        // System.err.println(String.format("[DFS] Skipping visited centroid: cid=%d, distance=%.4f",
-                          //      next.centroidId, next.distance));
+                        LOGGER.warn(String.format(
+                                "[DFS] Skipping visited centroid: cid=%d, distance=%.4f",
+                                next.centroidId, next.distance));
                         continue;
                     }
 
                     // Mark as visited and return
                     state.markVisited(next.centroidId);
-                    // System.err.println(String.format(
-                       //     "[DFS] Leaf frame pageId=%d returning centroid: cid=%d, distance=%.4f, nextIndex=%d/%d",
-                     //       topFrame.pageId, next.centroidId, next.distance, topFrame.nextIndex,
-// topFrame.sortedCentroids.size()));
+                    LOGGER.warn(String.format(
+                            "[DFS] Returning centroid: cid=%d, distance=%.4f, pageId=%d, nextIndex=%d/%d",
+                            next.centroidId, next.distance, topFrame.pageId, topFrame.nextIndex,
+                            topFrame.sortedCentroids.size()));
                     return ClusterSearchResult.create(next.pageId, next.tupleIndex, next.centroid, next.distance,
                             next.centroidId, next.directoryPageId);
                 }
@@ -1013,7 +1014,7 @@ public class VCTreeNavigationUtils {
         }
 
         // Stack exhausted, no more clusters
-        // System.err.println("[DFS] Stack exhausted, no more clusters available");
+        LOGGER.warn("[DFS] Stack exhausted, no more clusters available");
         return null;
     }
 
@@ -1064,8 +1065,9 @@ public class VCTreeNavigationUtils {
                                     first.distance, first.centroidId, first.directoryPageId);
                         }
                         // Skip visited centroid
-                        // System.err.println(String.format("[DFS descendToLeaf] Skipping visited centroid: cid=%d",
-                          //      first.centroidId));
+                        LOGGER.warn(String.format(
+                                "[DFS descendToLeaf] Skipping visited centroid: cid=%d",
+                                first.centroidId));
                     }
                     // All centroids in this leaf are visited
                     return null;

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeBlockedCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeBlockedCursor.java
@@ -26,7 +26,6 @@ import org.apache.hyracks.api.exceptions.HyracksDataException;
 import org.apache.hyracks.api.util.HyracksConstants;
 import org.apache.hyracks.data.std.primitive.ByteArrayPointable;
 import org.apache.hyracks.data.std.primitive.DoublePointable;
-import org.apache.hyracks.data.std.primitive.LongPointable;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -154,6 +153,7 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
         this.totalTuplesProcessed = 0;
         this.antimatterCancellations = 0;
         this.tuplesFilteredOut = 0;
+        this.addToTopKWindowCallCount = 0;
 
         // Get initial state
         LSMVCTreeCursorInitialState lsmInitialState = (LSMVCTreeCursorInitialState) initialState;
@@ -239,6 +239,9 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
             // Set first cursor for DFS fallback (like LSMVCTreeSearchCursor does)
             clusterStrategy.setFirstCursorForDFS(firstSearchCursor);
 
+            // Sync visited set so DFS fallback skips clusters already returned by level-wise
+            firstSearchCursor.setSharedVisitedSet(clusterStrategy.getVisitedCentroidIds());
+
             LOGGER.log(Level.INFO,
                     "[LSMVCTreeBlockedCursor] Initialized with queryVector dim={}, K={}, nprobe={}, epsilon={}",
                     queryVector.length, K, nprobe, epsilon);
@@ -261,11 +264,11 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
             this.dqc = firstCluster.distance;
         }
 
-        System.err.println(String.format(
-                "[LSMVCTreeBlockedCursor] First cluster: cid=%d, D(q,C)_full=%.4f, D(q,C)_quant=%.4f, dqc_used=%.4f, dirPage=%d, levelWise=%d",
+        LOGGER.log(Level.DEBUG,
+                "[LSMVCTreeBlockedCursor] First cluster: cid={}, D(q,C)_full={}, D(q,C)_quant={}, dqc_used={}, dirPage={}, levelWise={}",
                 firstCluster.centroidId, firstCluster.distance,
                 firstCluster.hasQuantizedDistance() ? firstCluster.quantizedDistance : Double.NaN, dqc,
-                firstCluster.directoryPageId, clusterStrategy.getLevelWiseClusterCount()));
+                firstCluster.directoryPageId, clusterStrategy.getLevelWiseClusterCount());
 
         // Perform the bidirectional search on first cluster
         openClusterAndSearch(firstCluster, queryVector, dqc);
@@ -277,14 +280,10 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
         while (!stopAdvancing) {
             if (clusterStrategy.shouldStopAdvancing(clustersExplored, topKWindow.size())) {
                 stopAdvancing = true;
-                System.err
-                        .println(String.format("[LSMVCTreeBlockedCursor] Stop advancing: clustersExplored=%d, topK=%d",
-                                clustersExplored, topKWindow.size()));
                 break;
             }
 
             if (!clusterStrategy.hasMoreClusters()) {
-                System.err.println("[LSMVCTreeBlockedCursor] No more clusters available");
                 break;
             }
 
@@ -293,19 +292,18 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
                 break;
             }
 
-            System.err.println(String.format(
-                    "[LSMVCTreeBlockedCursor] Advancing to cluster: cid=%d, D(q,C)_full=%.4f, D(q,C)_quant=%.4f, dqc_used=%.4f, dirPage=%d",
+            LOGGER.log(Level.DEBUG,
+                    "[LSMVCTreeBlockedCursor] Advancing to cluster: cid={}, D(q,C)_full={}, D(q,C)_quant={}, dirPage={}",
                     nextCluster.centroidId, nextCluster.distance,
-                    nextCluster.hasQuantizedDistance() ? nextCluster.quantizedDistance : Double.NaN, dqc,
-                    nextCluster.directoryPageId));
+                    nextCluster.hasQuantizedDistance() ? nextCluster.quantizedDistance : Double.NaN,
+                    nextCluster.directoryPageId);
 
             advanceAllComponentsToNextCluster(nextCluster);
             clustersExplored++;
         }
 
-        System.err.println(
-                String.format("[LSMVCTreeBlockedCursor] Multi-cluster probing complete: %d clusters probed, topK=%d",
-                        clustersExplored, topKWindow.size()));
+        LOGGER.log(Level.INFO, "[LSMVCTreeBlockedCursor] open() COMPLETE: {} clusters probed, topKWindow.size()={} (BEFORE consumption)",
+                clustersExplored, topKWindow.size());
     }
 
     /**
@@ -432,9 +430,7 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
                 ctx.pqes[i].reset(tupleCopy, dxc, antimatter);
                 ctx.queue.offer(ctx.pqes[i]);
 
-                System.err.println(String.format(
-                        "[seedQueue] dir=%s, comp=%d, dxc=%.6f, antimatter=%b, tupleClass=%s, fieldCount=%d",
-                        ctx.direction, i, dxc, antimatter, tuple.getClass().getSimpleName(), tuple.getFieldCount()));
+                // Per-tuple logging removed to avoid stderr blocking with large clusters
             }
         }
     }
@@ -448,6 +444,11 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
             // Process right direction
             if (!rightCtx.terminated) {
                 ITupleReference rightTuple = getNextValidTuple(rightCtx);
+                // Debug: log first few tuples to verify getNextValidTuple is working
+                if (iterCount < 3) {
+                    LOGGER.log(Level.INFO, "[bidir] RIGHT iter={}, tupleReturned={}, fields={}",
+                            iterCount, rightTuple != null, rightTuple != null ? rightTuple.getFieldCount() : -1);
+                }
                 if (rightTuple != null) {
                     double dxcFull = extractFullPrecisionDxc(rightTuple);
                     double dxcQuant = (quantizer != null) ? extractDistanceToCentroid(rightTuple) : Double.NaN;
@@ -459,17 +460,7 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
                         addToTopKWindow(rightTuple, dqx);
                     }
 
-                    // Log first few + every 10th tuple (include threshold when topK is full)
-                    if (true) {
-                        double kthDqx = topKWindow.isEmpty() ? Double.NaN : topKWindow.peek().dqx;
-                        double rThresh = kthDqx + dqc;
-                        double nextRightDxc =
-                                rightCtx.queue.isEmpty() ? Double.NaN : rightCtx.queue.peek().dxc;
-                        System.err.println(String.format(
-                                "[bidir] RIGHT #%d: D(x,C)_full=%.4f, D(x,C)_quant=%.4f, D(q,x)_quant=%.4f, D(q,C)_used=%.4f, topK=%d, kth_dqx=%.4f, threshold=%.4f, nextDxc=%.4f",
-                                iterCount, dxcFull, dxcQuant, dqx, dqc, topKWindow.size(), kthDqx, rThresh,
-                                nextRightDxc));
-                    }
+                    // Per-tuple logging removed to avoid stderr blocking with large clusters
 
                     // Check right termination: D(x',C) > max{D(q,x)} + D(q,C)
                     if (topKWindow.size() >= K && !rightCtx.queue.isEmpty()) {
@@ -477,20 +468,21 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
                         double threshold = topKWindow.peek().dqx + dqc;
                         if (nextDxc > threshold) {
                             rightCtx.terminated = true;
-                            System.err.println(String.format(
-                                    "[bidir] Right TERMINATED: nextDxc=%.4f > threshold=%.4f (kth_dqx=%.4f + dqc=%.4f)",
-                                    nextDxc, threshold, topKWindow.peek().dqx, dqc));
                         }
                     }
                 } else {
                     rightCtx.terminated = true;
-                    System.err.println("[bidir] Right EXHAUSTED");
                 }
             }
 
             // Process left direction
             if (!leftCtx.terminated) {
                 ITupleReference leftTuple = getNextValidTuple(leftCtx);
+                // Debug: log first few tuples to verify getNextValidTuple is working
+                if (iterCount < 3) {
+                    LOGGER.log(Level.INFO, "[bidir] LEFT iter={}, tupleReturned={}, fields={}",
+                            iterCount, leftTuple != null, leftTuple != null ? leftTuple.getFieldCount() : -1);
+                }
                 if (leftTuple != null) {
                     double dxcFull = extractFullPrecisionDxc(leftTuple);
                     double dxcQuant = (quantizer != null) ? extractDistanceToCentroid(leftTuple) : Double.NaN;
@@ -502,40 +494,29 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
                         addToTopKWindow(leftTuple, dqx);
                     }
 
-                    // Log first few + every 10th tuple (include threshold when topK is full)
-                    if (true) {
-                        double kthDqx = topKWindow.isEmpty() ? Double.NaN : topKWindow.peek().dqx;
-                        double lThresh = dqc - kthDqx;
-                        double nextLeftDxc =
-                                leftCtx.queue.isEmpty() ? Double.NaN : leftCtx.queue.peek().dxc;
-                        System.err.println(String.format(
-                                "[bidir] LEFT  #%d: D(x,C)_full=%.4f, D(x,C)_quant=%.4f, D(q,x)_quant=%.4f, D(q,C)_used=%.4f, topK=%d, kth_dqx=%.4f, threshold=%.4f, nextDxc=%.4f",
-                                iterCount, dxcFull, dxcQuant, dqx, dqc, topKWindow.size(), kthDqx, lThresh,
-                                nextLeftDxc));
-                    }
+                    // Per-tuple logging removed to avoid stderr blocking with large clusters
 
                     // Check left termination: D(x',C) < D(q,C) - max{D(q,x)}
+                    // Note: When threshold is negative (kth_dqx > dqc), left cannot terminate early
+                    // and must scan all tuples. This is expected when query is far from centroid.
                     if (topKWindow.size() >= K && !leftCtx.queue.isEmpty()) {
                         double nextDxc = leftCtx.queue.peek().dxc;
                         double threshold = dqc - topKWindow.peek().dqx;
                         if (nextDxc < threshold) {
                             leftCtx.terminated = true;
-                            System.err.println(String.format(
-                                    "[bidir] Left TERMINATED: nextDxc=%.4f < threshold=%.4f (dqc=%.4f - kth_dqx=%.4f)",
-                                    nextDxc, threshold, dqc, topKWindow.peek().dqx));
                         }
                     }
                 } else {
                     leftCtx.terminated = true;
-                    System.err.println("[bidir] Left EXHAUSTED");
                 }
             }
             iterCount++;
         }
 
-        System.err.println(
-                String.format("[LSMVCTreeBlockedCursor] Search complete: topK=%d, processed=%d, cancellations=%d",
-                        topKWindow.size(), totalTuplesProcessed, antimatterCancellations));
+        // Summary log kept for diagnostics
+        LOGGER.log(Level.DEBUG,
+                "[LSMVCTreeBlockedCursor] Search complete: topK={}, processed={}, cancellations={}",
+                topKWindow.size(), totalTuplesProcessed, antimatterCancellations);
     }
 
     // ==================== Antimatter Reconciliation ====================
@@ -589,16 +570,13 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
      */
     private boolean processTopElement(DirectionContext ctx, PriorityQueueElement checkElement)
             throws HyracksDataException {
-        System.err.println(String.format("[processTopElement] dir=%s, comp=%d, dxc=%.6f, antimatter=%b", ctx.direction,
-                checkElement.componentId, checkElement.dxc, checkElement.isAntimatter));
+        // Per-tuple logging removed to avoid stderr blocking with large clusters
 
         if (checkElement.isAntimatter) {
             // Antimatter - hold for cancellation check with next tuple
             ctx.outputElement = ctx.queue.poll();
             ctx.savedTuple = ctx.outputElement.tuple; // Save BEFORE advanceCursor modifies it
-            ctx.needPush = true;
-            System.err.println(String.format("[processTopElement] ANTIMATTER held: comp=%d, dxc=%.6f, fieldCount=%d",
-                    ctx.outputElement.componentId, ctx.outputElement.dxc, ctx.savedTuple.getFieldCount()));
+            ctx.needPush = false; // Fixed: advanceCursor called here, so don't call again in refillPendingElementCursor
             advanceCursor(ctx, ctx.outputElement.componentId);
             return false; // Continue processing
         }
@@ -620,18 +598,12 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
     private void processWithPendingElement(DirectionContext ctx, PriorityQueueElement checkElement)
             throws HyracksDataException {
         int cmpResult = compare(ctx.savedTuple, checkElement.tuple);
-        System.err.println(String.format(
-                "[processWithPending] dir=%s, pendingComp=%d pendingDxc=%.6f, checkComp=%d checkDxc=%.6f, cmpResult=%d",
-                ctx.direction, ctx.outputElement.componentId, ctx.outputElement.dxc, checkElement.componentId,
-                checkElement.dxc, cmpResult));
 
         if (cmpResult == 0) {
             // Same key - antimatter cancellation
-            System.err.println("[processWithPending] CANCELLATION!");
             performAntimatterCancellation(ctx, checkElement);
         } else {
             // Different key - discard antimatter, refill pending element's cursor
-            System.err.println("[processWithPending] No match, discarding antimatter");
             refillPendingElementCursor(ctx);
         }
     }
@@ -703,12 +675,9 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
             boolean antimatter = isAntimatter(tuple);
             ctx.pqes[componentId].reset(tupleCopy, dxc, antimatter);
             ctx.queue.offer(ctx.pqes[componentId]);
-
-            System.err.println(String.format("[advanceCursor] dir=%s, comp=%d, dxc=%.6f, antimatter=%b", ctx.direction,
-                    componentId, dxc, antimatter));
-        } else {
-            System.err.println(String.format("[advanceCursor] dir=%s, comp=%d, EXHAUSTED", ctx.direction, componentId));
+            // Per-tuple logging removed to avoid stderr blocking with large clusters
         }
+        // else: component exhausted, no more tuples
     }
 
     /**
@@ -724,11 +693,7 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
         int result = cmp.getComparators()[0].compare(tupleA.getFieldData(0), tupleA.getFieldStart(0),
                 tupleA.getFieldLength(0), tupleB.getFieldData(0), tupleB.getFieldStart(0), tupleB.getFieldLength(0));
 
-        double dxcA = extractDistanceToCentroid(tupleA);
-        double dxcB = extractDistanceToCentroid(tupleB);
-        System.err.println(String.format(
-                "[compare] field0(distance): dxcA=%.15f, dxcB=%.15f, cmpResult=%d, fieldsA=%d, fieldsB=%d", dxcA, dxcB,
-                result, tupleA.getFieldCount(), tupleB.getFieldCount()));
+        // Per-tuple logging removed to avoid stderr blocking with large clusters
 
         if (result != 0) {
             return result;
@@ -742,17 +707,12 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
 
             // Check if field exists in tuple before comparing
             if (fieldIdx >= tupleA.getFieldCount() || fieldIdx >= tupleB.getFieldCount()) {
-                System.err.println(String.format("[compare] field %d: SKIP (fieldsA=%d, fieldsB=%d)", fieldIdx,
-                        tupleA.getFieldCount(), tupleB.getFieldCount()));
                 break;
             }
 
             result = cmp.getComparators()[cmpIdx].compare(tupleA.getFieldData(fieldIdx), tupleA.getFieldStart(fieldIdx),
                     tupleA.getFieldLength(fieldIdx), tupleB.getFieldData(fieldIdx), tupleB.getFieldStart(fieldIdx),
                     tupleB.getFieldLength(fieldIdx));
-
-            System.err.println(String.format("[compare] field %d: lenA=%d, lenB=%d, cmpResult=%d", fieldIdx,
-                    tupleA.getFieldLength(fieldIdx), tupleB.getFieldLength(fieldIdx), result));
 
             if (result != 0) {
                 return result;
@@ -766,7 +726,16 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
      * Add tuple to top-K window if it improves the results.
      * IMPORTANT: We must copy the tuple because the cursor's tuple buffer is reused.
      */
+    // Debug counter for addToTopKWindow
+    private int addToTopKWindowCallCount = 0;
+
     private void addToTopKWindow(ITupleReference tuple, double dqx) throws HyracksDataException {
+        addToTopKWindowCallCount++;
+        // Log first few calls to see if we're even getting here
+        if (addToTopKWindowCallCount <= 3) {
+            LOGGER.log(Level.INFO, "[addToTopKWindow] call #{}, dqx={}, topKSize={}, K={}, tupleFields={}",
+                    addToTopKWindowCallCount, dqx, topKWindow.size(), K, tuple.getFieldCount());
+        }
         if (topKWindow.size() < K) {
             // Copy tuple before storing - the original buffer will be reused
             ITupleReference tupleCopy = TupleUtils.copyTuple(tuple);
@@ -801,17 +770,8 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
             return true;
         }
 
-        // Tuple fails filter - log for debugging
+        // Tuple fails filter
         tuplesFilteredOut++;
-        try {
-            long pkValue =
-                    LongPointable.getLong(tuple.getFieldData(pkStartField), tuple.getFieldStart(pkStartField) + 1);
-            System.err.println(String.format(
-                    "[LSMVCTreeBlockedCursor] Tuple FILTERED OUT (total filtered: %d) | pk=%d", tuplesFilteredOut,
-                    pkValue));
-        } catch (Exception e) {
-            // Ignore logging errors
-        }
         return false;
     }
 
@@ -880,21 +840,19 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
      * Check if tuple is antimatter.
      */
     private boolean isAntimatter(ITupleReference tuple) {
-        boolean result = false;
-        boolean isLSMTuple = tuple instanceof ILSMTreeTupleReference;
-        if (isLSMTuple) {
-            result = ((ILSMTreeTupleReference) tuple).isAntimatter();
+        if (tuple instanceof ILSMTreeTupleReference) {
+            return ((ILSMTreeTupleReference) tuple).isAntimatter();
         }
-        System.err.println(String.format("[isAntimatter] tupleClass=%s, isLSMTuple=%b, isAntimatter=%b, fieldCount=%d",
-                tuple.getClass().getSimpleName(), isLSMTuple, result, tuple.getFieldCount()));
-        return result;
+        return false;
     }
 
     // ==================== IIndexCursor Interface ====================
 
     @Override
     public boolean hasNext() throws HyracksDataException {
-        return !topKWindow.isEmpty();
+        boolean result = !topKWindow.isEmpty();
+        LOGGER.log(Level.INFO, "[hasNext] called, topKWindow.size()={}, returning={}", topKWindow.size(), result);
+        return result;
     }
 
     @Override
@@ -913,15 +871,11 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
     @Override
     public void close() throws HyracksDataException {
         if (isOpen) {
-            // Print final summary
-            System.err.println("\n========== LSMVCTreeBlockedCursor Search Summary ==========");
-            System.err.println(String.format("K=%d, nprobe=%d, epsilon=%.4f", K, nprobe, epsilon));
-            System.err.println(String.format("Clusters explored:          %d", clustersExplored));
-            System.err.println(String.format("Total tuples processed:     %d", totalTuplesProcessed));
-            System.err.println(String.format("Antimatter cancellations:   %d", antimatterCancellations));
-            System.err.println(String.format("Tuples filtered out:        %d", tuplesFilteredOut));
-            System.err.println(String.format("Top-K window size:          %d", topKWindow.size()));
-            System.err.println("============================================================\n");
+            // Summary logging via LOGGER (not stderr to avoid blocking)
+            LOGGER.log(Level.INFO,
+                    "[LSMVCTreeBlockedCursor] Summary: K={}, nprobe={}, clusters={}, processed={}, addToTopKCalls={}, cancellations={}, filtered={}, topK={}",
+                    K, nprobe, clustersExplored, totalTuplesProcessed, addToTopKWindowCallCount, antimatterCancellations, tuplesFilteredOut,
+                    topKWindow.size());
 
             // Close bidirectional cursors
             for (int i = 0; i < numComponents; i++) {

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeSearchCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeSearchCursor.java
@@ -47,6 +47,8 @@ import org.apache.hyracks.storage.common.MultiComparator;
 import org.apache.hyracks.storage.common.NoOpIndexCursorStats;
 import org.apache.hyracks.storage.common.util.IndexCursorUtils;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * LSM search cursor for Vector Clustering Tree.
@@ -78,6 +80,7 @@ import org.apache.logging.log4j.Level;
  * - Filters antimatter tuples and handles matter/antimatter cancellation
  */
 public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
+    private static final Logger LOGGER = LogManager.getLogger();
 
     // Accessor array for each component's VCTree
     private VectorClusteringTreeAccessor[] vcTreeAccessors;
@@ -167,9 +170,9 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
         this.tupleFilter = extractTupleFilter(searchPred);
         if (this.tupleFilter != null) {
             this.referenceFilterTuple = new ReferenceFrameTupleReference();
-            System.err.println("[LSMVCTreeSearchCursor] Tuple filter is SET - will filter INCLUDE field predicates");
-        } else {
-            System.err.println("[LSMVCTreeSearchCursor] Tuple filter is NULL - no INCLUDE field filtering");
+//            System.err.println("[LSMVCTreeSearchCursor] Tuple filter is SET - will filter INCLUDE field predicates");
+//        } else {
+//            System.err.println("[LSMVCTreeSearchCursor] Tuple filter is NULL - no INCLUDE field filtering");
         }
 
         // Initialize debug counters
@@ -240,6 +243,10 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
         // Open all cursors with the search predicate
         IndexCursorUtils.open(vcTreeAccessors, rangeCursors, searchPred);
 
+        LOGGER.warn(String.format(
+                "[LSMVCTreeSearchCursor] doOpen: numComponents=%d, K=%d, nprobe=%d, pkStartField=%d",
+                numVCTrees, K, nprobe, pkStartField));
+
         // Initialize strategy and set up DFS fallback
         if (numVCTrees > 0) {
             VectorClusteringSearchCursor firstCursor = (VectorClusteringSearchCursor) rangeCursors[0];
@@ -270,9 +277,9 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
                 ClusterSearchResult dfsCluster = firstCursor.getCurrentClusterResult();
                 if (dfsCluster != null && dfsCluster.centroidId != firstCluster.centroidId) {
                     // DFS found different cluster than level-wise! Re-open all cursors to level-wise[0]
-                    System.err.printf(
-                            "[LSMVCTreeSearchCursor] DFS found cid=%d but level-wise[0] is cid=%d - re-opening all cursors to level-wise[0]%n",
-                            dfsCluster.centroidId, firstCluster.centroidId);
+                    LOGGER.warn(String.format(
+                            "[LSMVCTreeSearchCursor] DFS found cid=%d but level-wise[0] is cid=%d - re-opening all cursors to level-wise[0]",
+                            dfsCluster.centroidId, firstCluster.centroidId));
 
                     for (int i = 0; i < numVCTrees; i++) {
                         if (rangeCursors[i] instanceof VectorClusteringSearchCursor) {
@@ -285,17 +292,17 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
                     }
                 }
 
-                System.err.printf(
-                        "[LSMVCTreeSearchCursor] Computed %d level-wise clusters, first cluster cid=%d marked visited%n",
-                        clusterStrategy.getLevelWiseClusterCount(), firstCluster.centroidId);
+                LOGGER.warn(String.format(
+                        "[LSMVCTreeSearchCursor] Computed %d level-wise clusters, first cluster cid=%d marked visited",
+                        clusterStrategy.getLevelWiseClusterCount(), firstCluster.centroidId));
             } else {
                 // No level-wise clusters - mark first cluster from DFS as visited
                 ClusterSearchResult dfsFallbackCluster = firstCursor.getCurrentClusterResult();
                 if (dfsFallbackCluster != null) {
                     visitedSet.add(dfsFallbackCluster.centroidId);
-                    System.err.printf(
-                            "[LSMVCTreeSearchCursor] Level-wise disabled, marked first DFS cluster as visited: cid=%d%n",
-                            dfsFallbackCluster.centroidId);
+                    LOGGER.warn(String.format(
+                            "[LSMVCTreeSearchCursor] Level-wise disabled, marked first DFS cluster as visited: cid=%d",
+                            dfsFallbackCluster.centroidId));
                 }
             }
         }
@@ -335,12 +342,32 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
         for (int i = 0; i < rangeCursors.length; i++) {
             if (rangeCursors[i].hasNext()) {
                 rangeCursors[i].next();
-                pqes[i].reset(rangeCursors[i].getTuple());
+                ITupleReference tuple = rangeCursors[i].getTuple();
+                pqes[i].reset(tuple);
                 outputPriorityQueue.offer(pqes[i]);
+
+//                // Log tuple being added to PQ
+//                try {
+//                    double dist = org.apache.hyracks.data.std.primitive.DoublePointable.getDouble(
+//                            tuple.getFieldData(0), tuple.getFieldStart(0));
+//                    int cid = org.apache.hyracks.data.std.primitive.IntegerPointable.getInteger(
+//                            tuple.getFieldData(1), tuple.getFieldStart(1));
+//                    byte[] pkData = tuple.getFieldData(2);
+//                    int pkStart = tuple.getFieldStart(2);
+//                    int pkLen = tuple.getFieldLength(2);
+//                    StringBuilder pkHex = new StringBuilder();
+//                    for (int j = 0; j < Math.min(pkLen, 40); j++) {
+//                        pkHex.append(String.format("%02x", pkData[pkStart + j] & 0xFF));
+//                    }
+//                    System.err.println(String.format(
+//                            "[initPQ] comp=%d added: dist=%.4f, cid=%d, pkHex=%s", i, dist, cid, pkHex.toString()));
+//                } catch (Exception e) {
+//                    System.err.println(String.format("[initPQ] comp=%d added (error logging: %s)", i, e.getMessage()));
+//                }
             } else {
                 // Cursor has no data in initial cluster - mark as exhausted
                 clusterExhausted[i] = true;
-                System.err.println(String.format(
+                LOGGER.warn(String.format(
                         "[LSMVCTreeSearchCursor] Component %d has empty initial cluster (marked exhausted)", i));
             }
         }
@@ -356,7 +383,7 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
         }
 
         if (allInitiallyExhausted) {
-            System.err.println("[LSMVCTreeSearchCursor] ALL components have empty initial cluster, advancing to next");
+            LOGGER.warn("[LSMVCTreeSearchCursor] ALL components have empty initial cluster, advancing to next");
             advanceAllComponentsToNextCluster();
         }
     }
@@ -415,21 +442,20 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
     public void doClose() throws HyracksDataException {
         // Print final reconciliation summary
         int minClustersProbed = getMinClustersProbed();
-        System.err.println("\n========== LSM Vector Index Search Summary ==========");
-        System.err
-                .println(String.format("Mode:                       %s", fullScanMode ? "MERGE (full scan)" : "QUERY"));
-        System.err.println(String.format("K=%d, nprobe=%d", K, nprobe));
-        System.err.println(String.format("Level-wise clusters:        %d",
+        LOGGER.warn("\n========== LSM Vector Index Search Summary ==========");
+        LOGGER.warn(String.format("Mode:                       %s", fullScanMode ? "MERGE (full scan)" : "QUERY"));
+        LOGGER.warn(String.format("K=%d, nprobe=%d", K, nprobe));
+        LOGGER.warn(String.format("Level-wise clusters:        %d",
                 clusterStrategy != null ? clusterStrategy.getLevelWiseClusterCount() : 0));
-        System.err.println(String.format("Level-wise phase complete:  %s",
+        LOGGER.warn(String.format("Level-wise phase complete:  %s",
                 clusterStrategy != null && clusterStrategy.isLevelWisePhaseComplete()));
-        System.err.println(String.format("Min clusters probed:        %d", minClustersProbed));
-        System.err.println(String.format("Total tuples processed:     %d", totalTuplesPopped));
-        System.err.println(String.format("Antimatter tuples detected: %d", antimatterTuplesDetected));
-        System.err.println(String.format("Cancellations made:         %d", cancellationsMade));
-        System.err.println(String.format("Tuples filtered out:        %d", tuplesFilteredOut));
-        System.err.println(String.format("doGetTuple() was called:    %d times", getTupleCallCount));
-        System.err.println("=====================================================\n");
+        LOGGER.warn(String.format("Min clusters probed:        %d", minClustersProbed));
+        LOGGER.warn(String.format("Total tuples processed:     %d", totalTuplesPopped));
+        LOGGER.warn(String.format("Antimatter tuples detected: %d", antimatterTuplesDetected));
+        LOGGER.warn(String.format("Cancellations made:         %d", cancellationsMade));
+        LOGGER.warn(String.format("Tuples filtered out:        %d", tuplesFilteredOut));
+        LOGGER.warn(String.format("doGetTuple() was called:    %d times", getTupleCallCount));
+        LOGGER.warn("=====================================================\n");
 
         super.doClose();
     }
@@ -539,19 +565,8 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
             return true;
         }
 
-        // Tuple fails filter - log for debugging
+        // Tuple fails filter
         tuplesFilteredOut++;
-        try {
-            long pkValue =
-                    LongPointable.getLong(tuple.getFieldData(pkStartField), tuple.getFieldStart(pkStartField) + 1);
-            long yearValue = LongPointable.getLong(tuple.getFieldData(pkStartField + 1),
-                    tuple.getFieldStart(pkStartField + 1) + 1);
-            System.err.println(
-                    String.format("[LSMVCTreeSearchCursor] Tuple FILTERED OUT (total filtered: %d) | pk=%d, year=%d",
-                            tuplesFilteredOut, pkValue, yearValue));
-        } catch (Exception e) {
-            // Ignore logging errors
-        }
         return false;
     }
 
@@ -785,10 +800,7 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
 
     @Override
     public ITupleReference doGetTuple() {
-        // Track how many times this method is called
         getTupleCallCount++;
-
-        // Return tuple from priority queue output element
         return outputElement != null ? outputElement.getTuple() : null;
     }
 
@@ -906,8 +918,10 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
         if (cursor.hasNext()) {
             // Current cluster/page has more data
             cursor.next();
-            e.reset(cursor.getTuple());
+            ITupleReference tuple = cursor.getTuple();
+            e.reset(tuple);
             outputPriorityQueue.offer(e);
+
             return;
         }
 
@@ -952,9 +966,9 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
         if (clusterStrategy.shouldStopAdvancing(minClustersExplored, resultsCollected)) {
             // We have enough results AND probed enough clusters - set flag to stop advancing
             stopAdvancing = true;
-//            System.err.println(
-//                    String.format("[LSMVCTreeSearchCursor] Early termination: minClustersExplored=%d, returned=%d",
-//                            minClustersExplored, resultsCollected));
+            LOGGER.warn(String.format(
+                    "[LSMVCTreeSearchCursor] Early termination: minClustersExplored=%d, returned=%d",
+                    minClustersExplored, resultsCollected));
             return;
         }
 
@@ -993,17 +1007,16 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
             ClusterSearchResult nextCluster = clusterStrategy.getNextCluster();
 
             if (nextCluster == null) {
-                // No more clusters available
-//                System.err.println("[LSMVCTreeSearchCursor] No more clusters available globally");
+                LOGGER.warn("[LSMVCTreeSearchCursor] No more clusters available globally");
                 for (int i = 0; i < clusterExhausted.length; i++) {
                     clusterExhausted[i] = true;
                 }
                 return;
             }
 
-//            System.err.println(
-//                    String.format("[LSMVCTreeSearchCursor] Global cluster selected: cid=%d, distance=%.4f, dirPage=%d",
-//                            nextCluster.centroidId, nextCluster.distance, nextCluster.directoryPageId));
+            LOGGER.warn(String.format(
+                    "[LSMVCTreeSearchCursor] Global cluster selected: cid=%d, distance=%.4f, dirPage=%d",
+                    nextCluster.centroidId, nextCluster.distance, nextCluster.directoryPageId));
 
             // Tell ALL components to open this SAME cluster (using O(1) directoryPageId access)
             for (int i = 0; i < rangeCursors.length; i++) {
@@ -1046,16 +1059,15 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
         // Check if cluster has data
         if (hasData && vcCursor.hasNext()) {
             vcCursor.next();
+            ITupleReference tuple = vcCursor.getTuple();
             PriorityQueueElement pqe = pqes[componentIndex];
-            pqe.reset(vcCursor.getTuple());
+            pqe.reset(tuple);
             outputPriorityQueue.offer(pqe);
-//            System.err.println(
-//                    String.format("[LSMVCTreeSearchCursor] Component %d opened cluster cid=%d (has data, O(1) access)",
-//                            componentIndex, cluster.centroidId));
+
         } else {
             clusterExhausted[componentIndex] = true;
-//            System.err.println(String.format("[LSMVCTreeSearchCursor] Component %d cluster cid=%d is empty",
-//                    componentIndex, cluster.centroidId));
+            LOGGER.warn(String.format("[advCluster] comp=%d cluster=%d is EMPTY",
+                    componentIndex, cluster.centroidId));
         }
     }
 

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/NprobeClusterSelectionStrategy.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/NprobeClusterSelectionStrategy.java
@@ -30,6 +30,8 @@ import org.apache.hyracks.storage.am.vector.impls.ClusterSearchResult;
 import org.apache.hyracks.storage.am.vector.impls.VectorClusteringSearchCursor;
 import org.apache.hyracks.storage.am.vector.impls.VectorClusteringTree;
 import org.apache.hyracks.storage.am.vector.utils.VCTreeNavigationUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Nprobe-based cluster selection strategy.
@@ -41,6 +43,7 @@ import org.apache.hyracks.storage.am.vector.utils.VCTreeNavigationUtils;
  * Stopping condition: minClustersExplored >= nprobe AND resultsCollected >= K
  */
 public class NprobeClusterSelectionStrategy implements IClusterSelectionStrategy {
+    private static final Logger LOGGER = LogManager.getLogger();
 
     // Parameters
     private final int nprobe;
@@ -96,11 +99,12 @@ public class NprobeClusterSelectionStrategy implements IClusterSelectionStrategy
                     globalClusterIndex = 1; // Skip first cluster in getNextCluster()
                 }
 
-                // System.err.println(String.format("[NprobeStrategy] Computed %d level-wise clusters with epsilon=%.2f",
-                    //    globalLevelWiseClusters != null ? globalLevelWiseClusters.size() : 0, epsilon));
+                LOGGER.warn(String.format(
+                        "[NprobeStrategy] Computed %d level-wise clusters with epsilon=%.2f",
+                        globalLevelWiseClusters != null ? globalLevelWiseClusters.size() : 0, epsilon));
             } catch (Exception e) {
-                // System.err.println(
-                 //       String.format("[NprobeStrategy] Failed to compute level-wise clusters: %s", e.getMessage()));
+                LOGGER.warn(String.format(
+                        "[NprobeStrategy] Failed to compute level-wise clusters: %s", e.getMessage()));
                 globalLevelWiseClusters = null;
             }
         }
@@ -118,14 +122,16 @@ public class NprobeClusterSelectionStrategy implements IClusterSelectionStrategy
             // Mark visited for DFS fallback deduplication
             visitedCentroidIds.add(nextCluster.centroidId);
 
-            // System.err.println(
-              //      String.format("[NprobeStrategy] Level-wise: cluster %d/%d (cid=%d, distance=%.4f, dirPage=%d)",
-                //            globalClusterIndex, globalLevelWiseClusters.size(), nextCluster.centroidId,
-                 //           nextCluster.distance, nextCluster.directoryPageId));
+            LOGGER.warn(String.format(
+                    "[NprobeStrategy] Level-wise: cluster %d/%d (cid=%d, distance=%.4f, dirPage=%d)",
+                    globalClusterIndex, globalLevelWiseClusters.size(), nextCluster.centroidId,
+                    nextCluster.distance, nextCluster.directoryPageId));
 
             if (globalClusterIndex >= globalLevelWiseClusters.size()) {
                 levelWisePhaseComplete = true;
-                // System.err.println("[NprobeStrategy] Level-wise phase complete, DFS fallback next");
+                LOGGER.warn(String.format(
+                        "[NprobeStrategy] Level-wise phase COMPLETE. Visited centroids: %s",
+                        visitedCentroidIds));
             }
 
             return nextCluster;
@@ -141,12 +147,15 @@ public class NprobeClusterSelectionStrategy implements IClusterSelectionStrategy
         ClusterSearchResult next = firstCursor.findNextClusterDFS();
 
         if (next == null) {
-            // System.err.println("[NprobeStrategy] DFS exhausted, no more clusters");
+            LOGGER.warn(String.format(
+                    "[NprobeStrategy] DFS exhausted, no more clusters. Visited centroids: %s",
+                    visitedCentroidIds));
             return null;
         }
 
-        // System.err.println(String.format("[NprobeStrategy] DFS fallback: cluster cid=%d, distance=%.4f, dirPage=%d",
-           //     next.centroidId, next.distance, next.directoryPageId));
+        LOGGER.warn(String.format(
+                "[NprobeStrategy] DFS fallback: cluster cid=%d, distance=%.4f, dirPage=%d",
+                next.centroidId, next.distance, next.directoryPageId));
 
         return next;
     }


### PR DESCRIPTION
VCTreeStaticStructureBuilder.advancePosition() sets nextLeaf to link the last page of one cluster to the first page of the next, but did not explicitly clear the overflow flag. Since initBuffer()/ByteBuffer.clear() do not zero the flag byte, stale overflow bits from confiscated pages caused collectLeafCentroidsForLevelWise() to follow the chain across cluster boundaries, collecting the same centroids twice.

Fix: explicitly call setOverflowFlagBit(false) in the inter-cluster linking path of advancePosition().

Also converts System.err.println debug output to LOGGER.warn across LSMVCTreeSearchCursor, LSMVCTreeBlockedCursor, NprobeClusterSelectionStrategy, and VCTreeNavigationUtils, and adds diagnostic logging for duplicate centroid detection and tuple deserialization in doGetTuple().