### PR TITLE
Fix concurrency issues in VCTree memory component initialization and directory page split

### DIFF
--- a/hyracks-fullstack/algebricks/algebricks-runtime/src/main/java/org/apache/hyracks/algebricks/runtime/operators/aggreg/AggregatePushRuntime.java
+++ b/hyracks-fullstack/algebricks/algebricks-runtime/src/main/java/org/apache/hyracks/algebricks/runtime/operators/aggreg/AggregatePushRuntime.java
@@ -105,7 +105,6 @@ public class AggregatePushRuntime extends AbstractOneInputOneOutputOneFramePushR
     }
 
     private void processTuple(FrameTupleReference tupleRef) throws HyracksDataException {
-        //        System.err.println("AggregatePushRuntime.processTuple: processing tuple");
         for (IAggregateEvaluator aggEval : aggEvals) {
             aggEval.step(tupleRef);
         }

--- a/hyracks-fullstack/algebricks/algebricks-runtime/src/main/java/org/apache/hyracks/algebricks/runtime/operators/std/StreamSelectRuntimeFactory.java
+++ b/hyracks-fullstack/algebricks/algebricks-runtime/src/main/java/org/apache/hyracks/algebricks/runtime/operators/std/StreamSelectRuntimeFactory.java
@@ -137,7 +137,6 @@ public class StreamSelectRuntimeFactory extends AbstractOneInputOneOutputRuntime
             tAccess.reset(buffer);
             int nTuple = tAccess.getTupleCount();
             for (int t = 0; t < nTuple; t++) {
-                //                System.err.println("Stre" + "amSelectRuntime.nextFrame: processing tuple " + t);
                 tRef.reset(tAccess, t);
                 eval.evaluate(tRef, p);
                 if (bbi.getBooleanValue(p.getByteArray(), p.getStartOffset(), p.getLength())) {

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/frames/VectorClusteringMetadataFrame.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/frames/VectorClusteringMetadataFrame.java
@@ -29,7 +29,6 @@ import org.apache.hyracks.storage.am.common.api.ITreeIndexTupleWriter;
 import org.apache.hyracks.storage.am.common.frames.FrameOpSpaceStatus;
 import org.apache.hyracks.storage.am.common.ophelpers.FindTupleMode;
 import org.apache.hyracks.storage.am.common.ophelpers.FindTupleNoExactMatchPolicy;
-import org.apache.hyracks.storage.am.common.tuples.SimpleTupleReference;
 import org.apache.hyracks.storage.am.vector.api.IVectorClusteringMetadataFrame;
 
 /**
@@ -187,23 +186,37 @@ public class VectorClusteringMetadataFrame extends VectorClusteringNSMFrame impl
 
     /**
      * Split metadata frame when it becomes full.
+     * Uses a copy-and-reinitialize approach to avoid page fragmentation from in-place deletes.
      */
     public void split(IVectorClusteringMetadataFrame rightFrame, ITupleReference tuple) throws HyracksDataException {
         int tupleCount = getTupleCount();
         int splitIndex = tupleCount / 2;
 
-        // Move second half of tuples to right frame
+        // Copy all tuples out using TupleUtils.copyTuple (returns ArrayTupleReference
+        // which works with tupleWriter.writeTuple via the ITupleReference interface)
+        ITupleReference[] leftTuples = new ITupleReference[splitIndex];
+        for (int i = 0; i < splitIndex; i++) {
+            frameTuple.resetByTupleIndex(this, i);
+            leftTuples[i] = TupleUtils.copyTuple(frameTuple);
+        }
+        ITupleReference[] rightTuples = new ITupleReference[tupleCount - splitIndex];
         for (int i = splitIndex; i < tupleCount; i++) {
             frameTuple.resetByTupleIndex(this, i);
-            SimpleTupleReference tupleCopy = new SimpleTupleReference();
-            copyTuple(frameTuple, tupleCopy);
-            rightFrame.insert(tupleCopy, rightFrame.getTupleCount());
+            rightTuples[i - splitIndex] = TupleUtils.copyTuple(frameTuple);
         }
 
-        // Remove moved tuples from left frame
-        for (int i = tupleCount - 1; i >= splitIndex; i--) {
-            frameTuple.resetByTupleIndex(this, i);
-            delete(frameTuple, i);
+        // Reinitialize both frames to clean state
+        initBuffer((byte) 0);
+        rightFrame.initBuffer((byte) 0);
+
+        // Re-insert left half tuples
+        for (int i = 0; i < leftTuples.length; i++) {
+            insert(leftTuples[i], i);
+        }
+
+        // Re-insert right half tuples
+        for (int i = 0; i < rightTuples.length; i++) {
+            rightFrame.insert(rightTuples[i], i);
         }
 
         // Insert new tuple into appropriate frame
@@ -212,7 +225,6 @@ public class VectorClusteringMetadataFrame extends VectorClusteringNSMFrame impl
             int insertIndex = findInsertPosition(newMaxDistance);
             insert(tuple, insertIndex);
         } else {
-            // Use the findInsertPosition method instead of interface method
             int insertIndex = ((VectorClusteringMetadataFrame) rightFrame).findInsertPosition(newMaxDistance);
             rightFrame.insert(tuple, insertIndex);
         }
@@ -225,16 +237,6 @@ public class VectorClusteringMetadataFrame extends VectorClusteringNSMFrame impl
         byte[] data = tuple.getFieldData(0);
         int offset = tuple.getFieldStart(0);
         return DoublePointable.getDouble(data, offset);
-    }
-
-    /**
-     * Copy tuple data to a new SimpleTupleReference.
-     */
-    private void copyTuple(ITupleReference source, SimpleTupleReference target) throws HyracksDataException {
-        // Use TupleUtils.copyTuple to properly copy the tuple without deprecated constructs
-        ITupleReference copiedTuple = TupleUtils.copyTuple(source);
-        target.setFieldCount(copiedTuple.getFieldCount());
-        target.resetByTupleOffset(copiedTuple.getFieldData(0), 0);
     }
 
     /**

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTree.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTree.java
@@ -845,7 +845,8 @@ public class VectorClusteringTree extends AbstractTreeIndex {
 
         // Allocate a new metadata page
         int newMetadataPageId = freePageManager.takePage(ctx.getMetaFrame());
-        ICachedPage newMetadataPage = bufferCache.pin(BufferedFileHandle.getDiskPageId(getFileId(), newMetadataPageId));
+        ICachedPage newMetadataPage =
+                bufferCache.pin(BufferedFileHandle.getDiskPageId(getFileId(), newMetadataPageId), NEW);
 
         try {
             newMetadataPage.acquireWriteLatch();
@@ -1031,7 +1032,11 @@ public class VectorClusteringTree extends AbstractTreeIndex {
         initialized = true;
     }
 
-    public void setStaticStructure(VectorClusteringTreeAccessor staticAccessor) throws HyracksDataException {
+    public synchronized void setStaticStructure(VectorClusteringTreeAccessor staticAccessor)
+            throws HyracksDataException {
+        if (initialized) {
+            return; // Already initialized, skip
+        }
         VectorClusteringTree staticStructure = staticAccessor.getIndex();
         ITreeIndexMetadataFrame metaFrame = staticAccessor.getOpContext().getMetaFrame();
         int maxPageId = staticStructure.getPageManager().getMaxPageId(metaFrame);

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTree.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTree.java
@@ -50,6 +50,7 @@ import org.apache.hyracks.storage.am.lsm.common.api.ILSMIOOperationScheduler;
 import org.apache.hyracks.storage.am.lsm.common.api.ILSMIndexAccessor;
 import org.apache.hyracks.storage.am.lsm.common.api.ILSMIndexFileManager;
 import org.apache.hyracks.storage.am.lsm.common.api.ILSMIndexOperationContext;
+import org.apache.hyracks.storage.am.lsm.common.api.ILSMMemoryComponent;
 import org.apache.hyracks.storage.am.lsm.common.api.ILSMMergePolicy;
 import org.apache.hyracks.storage.am.lsm.common.api.ILSMOperationTracker;
 import org.apache.hyracks.storage.am.lsm.common.api.ILSMPageWriteCallbackFactory;
@@ -165,13 +166,38 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
         }
     }
 
-    public void setStaticStructure(LSMVCTreeDiskComponent staticStructure) {
+    public void setStaticStructure(LSMVCTreeDiskComponent staticStructure) throws HyracksDataException {
         this.staticStructure = staticStructure;
         staticStructure.setInitialized();
+        if (memoryComponentsAllocated) {
+            initializeMemoryComponentsStaticStructure();
+        }
     }
 
     public void setInitialized(LSMVCTreeDiskComponent diskComponent) {
         diskComponent.setInitialized();
+    }
+
+    @Override
+    public synchronized void allocateMemoryComponents() throws HyracksDataException {
+        super.allocateMemoryComponents();
+        initializeMemoryComponentsStaticStructure();
+    }
+
+    private void initializeMemoryComponentsStaticStructure() throws HyracksDataException {
+        if (staticStructure == null) {
+            return; // Not yet loaded (during initial index creation)
+        }
+        for (ILSMMemoryComponent memComponent : memoryComponents) {
+            LSMVCTreeMemoryComponent vcMemComponent = (LSMVCTreeMemoryComponent) memComponent;
+            VectorClusteringTree vcTree = vcMemComponent.getIndex();
+            if (!vcTree.isInitialized()) {
+                VectorClusteringTree.VectorClusteringTreeAccessor staticAccessor =
+                        (VectorClusteringTree.VectorClusteringTreeAccessor) staticStructure.getIndex()
+                                .createAccessor(NoOpIndexAccessParameters.INSTANCE);
+                vcTree.setStaticStructure(staticAccessor);
+            }
+        }
     }
 
     protected ILSMDiskComponent createStaticStructure(ILSMDiskComponentFactory factory,
@@ -309,55 +335,12 @@ public class LSMVCTree extends AbstractLSMIndex implements ITreeIndex {
     }
 
     private boolean insert(ITupleReference tuple, LSMVCTreeOpContext ctx) throws HyracksDataException {
-        // TODO: Implement vector-specific duplicate checking logic
-        VectorClusteringTree.VectorClusteringTreeAccessor memoryComponentAccessor =
-                (VectorClusteringTree.VectorClusteringTreeAccessor) (ctx.getCurrentMutableVCTreeAccessor());
-        VectorClusteringTree.VectorClusteringTreeAccessor staticAccessor =
-                (VectorClusteringTree.VectorClusteringTreeAccessor) getStaticStructure().getIndex()
-                        .createAccessor(NoOpIndexAccessParameters.INSTANCE);
-
-        if (!memoryComponentAccessor.getIndex().isInitialized()) {
-            memoryComponentAccessor.getIndex().setStaticStructure(staticAccessor);
-        }
-
-        memoryComponentAccessor.insert(tuple);
-
+        ctx.getCurrentMutableVCTreeAccessor().insert(tuple);
         return true;
     }
 
-    /**
-     * Handles delete operation for vector index.
-     * <p>
-     * Delete flow:
-     * 1. Call delete() on VectorClusteringTreeAccessor with the original input tuple
-     * 2. VectorClusteringTreeAccessor.delete() sets operation to DELETE and calls insertVector()
-     * 3. insertVector() navigates, calculates distance, and constructs data tuple
-     * 4. Based on operation type (DELETE), creates antimatter tuple with bit 7 set
-     * 5. Antimatter tuple is inserted into data pages
-     *
-     * This approach reuses all existing insertVector() logic and only differs in
-     * the antimatter bit being set when the operation type is DELETE.
-     */
     private void delete(ITupleReference tuple, LSMVCTreeOpContext ctx) throws HyracksDataException {
-        // Get the current mutable VectorClusteringTree accessor
-        VectorClusteringTree.VectorClusteringTreeAccessor memoryComponentAccessor =
-                (ctx.getCurrentMutableVCTreeAccessor());
-        VectorClusteringTree.VectorClusteringTreeAccessor staticAccessor =
-                (VectorClusteringTree.VectorClusteringTreeAccessor) getStaticStructure().getIndex()
-                        .createAccessor(NoOpIndexAccessParameters.INSTANCE);
-
-        // Ensure static structure is initialized (same pattern as insert)
-        if (!memoryComponentAccessor.getIndex().isInitialized()) {
-            memoryComponentAccessor.getIndex().setStaticStructure(staticAccessor);
-        }
-
-        System.err.println("[LSMVCTree.delete] Calling VectorClusteringTreeAccessor.delete(), Thread="
-                + Thread.currentThread().getId());
-
-        // Call delete() which will set operation to DELETE and delegate to insertVector()
-        // insertVector() will create an antimatter tuple based on the DELETE operation
-        memoryComponentAccessor.delete(tuple);
-
+        ctx.getCurrentMutableVCTreeAccessor().delete(tuple);
     }
 
     @Override


### PR DESCRIPTION
Fix concurrency issues in VCTree memory component initialization and directory page split
- Centralize static structure initialization in LSMVCTree.allocateMemoryComponents()
  instead of lazy per-insert/delete init to avoid races between concurrent threads
- Make VectorClusteringTree.setStaticStructure() synchronized with double-check guard
- Fix bufferCache.pin() to use NEW flag for freshly allocated metadata pages
- Rewrite metadata frame split to copy-and-reinitialize instead of in-place deletes
  to prevent page fragmentation under concurrent access