### PR TITLE
Fix uninitialized overflow flag in VCTree frames

### DIFF
--- a/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/entitytupletranslators/IndexTupleTranslator.java
+++ b/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/entitytupletranslators/IndexTupleTranslator.java
@@ -844,12 +844,18 @@ public class IndexTupleTranslator extends AbstractTupleTranslator<Index> {
         // Handle case where WITH properties are null (no WITH clause was specified)
         int dimension = -1;
         int train_list = -1;
+        int num_clusters = -1;
         String quantization = "INVALID";
         String similarity = "INVALID";
 
         if (properties != null) {
             dimension = properties.getOptionalInt("dimension", -1);
+            // Accept both "train_list_number" (from SQL++ WITH clause) and "train_list" (from metadata roundtrip)
             train_list = properties.getOptionalInt("train_list_number", -1);
+            if (train_list < 0) {
+                train_list = properties.getOptionalInt("train_list", -1);
+            }
+            num_clusters = properties.getOptionalInt("num_clusters", -1);
             quantization = properties.getOptionalString("quantization", "INVALID");
             similarity = properties.getOptionalString("similarity", "INVALID");
         }
@@ -861,7 +867,7 @@ public class IndexTupleTranslator extends AbstractTupleTranslator<Index> {
             throw new HyracksDataException("No train_list_number or percentage defined");
         }
 
-        if (similarity == "INVALID") {
+        if ("INVALID".equals(similarity)) {
             throw new HyracksDataException("No similarity metric defined");
         }
         nameValue.reset();
@@ -877,6 +883,15 @@ public class IndexTupleTranslator extends AbstractTupleTranslator<Index> {
         fieldValue.reset();
         int32Serde.serialize(new AInt32(train_list), fieldValue.getDataOutput());
         recordBuilder.addField(nameValue, fieldValue);
+
+        if (num_clusters > 0) {
+            nameValue.reset();
+            aString.setValue("num_clusters");
+            stringSerde.serialize(aString, nameValue.getDataOutput());
+            fieldValue.reset();
+            int32Serde.serialize(new AInt32(num_clusters), fieldValue.getDataOutput());
+            recordBuilder.addField(nameValue, fieldValue);
+        }
 
         if (!"INVALID".equals(quantization)) {
             nameValue.reset();
@@ -903,6 +918,7 @@ public class IndexTupleTranslator extends AbstractTupleTranslator<Index> {
         // Default values (matching writeWithProperties defaults)
         int dimension = -1;
         int train_list = -1;
+        int num_clusters = -1;
         String quantization = "INVALID";
         String similarity = "INVALID";
 
@@ -921,6 +937,15 @@ public class IndexTupleTranslator extends AbstractTupleTranslator<Index> {
             IAObject trainListObj = indexRecord.getValueByPos(trainListPos);
             if (trainListObj != null && trainListObj.getType().getTypeTag() == ATypeTag.INTEGER) {
                 train_list = ((AInt32) trainListObj).getIntegerValue();
+            }
+        }
+
+        // Read num_clusters field
+        int numClustersPos = indexRecord.getType().getFieldIndex("num_clusters");
+        if (numClustersPos >= 0) {
+            IAObject numClustersObj = indexRecord.getValueByPos(numClustersPos);
+            if (numClustersObj != null && numClustersObj.getType().getTypeTag() == ATypeTag.INTEGER) {
+                num_clusters = ((AInt32) numClustersObj).getIntegerValue();
             }
         }
 
@@ -943,7 +968,7 @@ public class IndexTupleTranslator extends AbstractTupleTranslator<Index> {
         }
 
         // Reconstruct AdmObjectNode only if at least one field differs from default
-        boolean hasNonDefaultValues = (dimension != -1) || (train_list != -1)
+        boolean hasNonDefaultValues = (dimension != -1) || (train_list != -1) || (num_clusters != -1)
                 || (!"default".equals(quantization) && !"INVALID".equals(quantization))
                 || (!"euclidean".equals(similarity) && !"INVALID".equals(similarity));
 
@@ -951,25 +976,19 @@ public class IndexTupleTranslator extends AbstractTupleTranslator<Index> {
             return null;
         }
 
-        //        if(dimension < 0){
-        //            throw new HyracksDataException("No dimensions defined");
-        //        }
-        //        if(train_list < 0){
-        //            throw new HyracksDataException("No train_list_number or percentage defined");
-        //        }
-        //
-        //        if(similarity == "INVALID"){
-        //            throw new HyracksDataException("No similarity metric defined");
-        //        }
-
         AdmObjectNode withObjectNode = new AdmObjectNode();
 
         if (dimension != -1) {
             withObjectNode.set("dimension", new AdmBigIntNode(dimension));
         }
 
+        // Use "train_list_number" key to match what consumers expect (SecondaryVectorOperationsHelper, writeWithProperties)
         if (train_list != -1) {
-            withObjectNode.set("train_list", new AdmBigIntNode(train_list));
+            withObjectNode.set("train_list_number", new AdmBigIntNode(train_list));
+        }
+
+        if (num_clusters != -1) {
+            withObjectNode.set("num_clusters", new AdmBigIntNode(num_clusters));
         }
 
         if (!"default".equals(quantization) && !"INVALID".equals(quantization)) {

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/frames/VectorClusteringInteriorFrame.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/frames/VectorClusteringInteriorFrame.java
@@ -48,6 +48,7 @@ public class VectorClusteringInteriorFrame extends VectorClusteringNSMFrame impl
     public void initBuffer(byte level) {
         super.initBuffer(level);
         buf.putInt(NEXT_PAGE_OFFSET, -1); // Initialize next page pointer to -1
+        buf.put(OVERFLOW_FLAG_OFFSET, (byte) 0); // Initialize overflow flag to false
     }
 
     @Override

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/frames/VectorClusteringLeafFrame.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/frames/VectorClusteringLeafFrame.java
@@ -49,6 +49,7 @@ public class VectorClusteringLeafFrame extends VectorClusteringNSMFrame implemen
     public void initBuffer(byte level) {
         super.initBuffer(level);
         buf.putInt(NEXT_PAGE_OFFSET, -1); // Initialize next leaf pointer to -1
+        buf.put(OVERFLOW_FLAG_OFFSET, (byte) 0); // Initialize overflow flag to false
     }
 
     @Override

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringSearchCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringSearchCursor.java
@@ -18,8 +18,13 @@
  */
 package org.apache.hyracks.storage.am.vector.impls;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 
 import org.apache.hyracks.api.exceptions.HyracksDataException;
@@ -63,6 +68,12 @@ public class VectorClusteringSearchCursor implements IIndexCursor {
     // Centroid-to-directory-page mapping (memory components only, null for disk)
     private int[] centroidDirPageMap;
     private int firstLeafCentroidIdForMap;
+    // Lazily-built centroid→directoryPageId map for disk components.
+    // When centroidDirPageMap is null and openClusterByResult() is called,
+    // the ClusterSearchResult's directoryPageId may be from a DIFFERENT component
+    // (e.g., static structure with predicted IDs). This map resolves the correct
+    // directory page ID by scanning this component's own leaf pages.
+    private Map<Integer, Long> localCentroidDirPageMap;
 
     // Cursor state fields
     /* Metadata page for current cluster */
@@ -891,10 +902,11 @@ public class VectorClusteringSearchCursor implements IIndexCursor {
      * For memory components: uses centroidDirPageMap for O(1) lookup (the map
      * translates centroid IDs to VBC directory page IDs).
      *
-     * For disk components: uses the directoryPageId already stored in the
-     * ClusterSearchResult. This value was read directly from the leaf frame's
-     * metadataPagePointer during level-wise or DFS navigation, so it is the
-     * correct page ID for this component's buffer cache.
+     * For disk components: builds a lazy local map by scanning this component's
+     * own leaf pages. This is necessary because the ClusterSearchResult's
+     * directoryPageId may come from a DIFFERENT component (e.g., level-wise
+     * computation reads the static structure's leaf pages, which have predicted
+     * directory page IDs that don't match this disk component's actual IDs).
      */
     private long getMetadataPageIdFromCluster(ClusterSearchResult clusterResult) throws HyracksDataException {
         // Memory components: use centroidDirPageMap for O(1) lookup
@@ -905,11 +917,91 @@ public class VectorClusteringSearchCursor implements IIndexCursor {
             }
         }
 
-        // Disk components: use the directoryPageId already in the ClusterSearchResult.
-        // This was read from the leaf frame during navigation and is valid for
-        // this component's data buffer cache.
-        // Returns -1 for empty clusters (no data assigned); callers handle -1 gracefully.
+        // Disk components: resolve directoryPageId locally by scanning this
+        // component's own leaf pages (which have correct IDs from VCTreeBulkLoader).
+        if (localCentroidDirPageMap == null) {
+            buildLocalCentroidDirPageMap();
+        }
+        if (localCentroidDirPageMap != null) {
+            Long dirPageId = localCentroidDirPageMap.get(clusterResult.centroidId);
+            if (dirPageId != null) {
+                return dirPageId;
+            }
+        }
+
+        // Fallback: use directoryPageId from ClusterSearchResult
         return clusterResult.directoryPageId;
+    }
+
+    /**
+     * Build a centroidId → directoryPageId map by scanning this component's own leaf pages.
+     * Uses BFS from root to find all leaf pages, then reads each leaf tuple's
+     * centroidId and metadataPagePointer to build the map.
+     *
+     * This is needed because ClusterSearchResults from level-wise computation
+     * carry directoryPageIds from the static structure (predicted sequential IDs),
+     * which don't match this disk component's actual directory page IDs
+     * (set correctly by VCTreeBulkLoader.end()).
+     */
+    private void buildLocalCentroidDirPageMap() throws HyracksDataException {
+        localCentroidDirPageMap = new HashMap<>();
+
+        // BFS from root through the tree to find all leaf pages
+        Queue<Integer> queue = new ArrayDeque<>();
+        queue.add(rootPageId);
+        Set<Integer> visitedPages = new HashSet<>();
+
+        while (!queue.isEmpty()) {
+            int pageId = queue.poll();
+            if (!visitedPages.add(pageId)) {
+                continue;
+            }
+
+            ICachedPage page = bufferCache.pin(BufferedFileHandle.getDiskPageId(fileId, pageId));
+            try {
+                page.acquireReadLatch();
+
+                // Use leaf frame to check page level (isLeaf works on any page type)
+                IVectorClusteringLeafFrame lf = createLeafFrame();
+                lf.setPage(page);
+
+                if (lf.isLeaf()) {
+                    // Leaf page: collect centroidId → metadataPagePointer mappings
+                    int tc = lf.getTupleCount();
+                    for (int i = 0; i < tc; i++) {
+                        int centroidId = lf.getCentroidId(i);
+                        long dirPageId = lf.getMetadataPagePointer(i);
+                        localCentroidDirPageMap.put(centroidId, dirPageId);
+                    }
+                    // Follow overflow chain
+                    if (lf.getOverflowFlagBit()) {
+                        int nextLeafPage = lf.getNextLeaf();
+                        if (nextLeafPage >= 0) {
+                            queue.add(nextLeafPage);
+                        }
+                    }
+                } else {
+                    // Interior page: enqueue all children
+                    IVectorClusteringInteriorFrame intFrame = createInteriorFrame();
+                    intFrame.setPage(page);
+
+                    int tc = intFrame.getTupleCount();
+                    for (int i = 0; i < tc; i++) {
+                        queue.add(intFrame.getChildPageId(i));
+                    }
+                    // Follow overflow chain for interior pages
+                    if (intFrame.getOverflowFlagBit()) {
+                        int nextPage = intFrame.getNextPage();
+                        if (nextPage >= 0) {
+                            queue.add(nextPage);
+                        }
+                    }
+                }
+            } finally {
+                page.releaseReadLatch();
+                bufferCache.unpin(page);
+            }
+        }
     }
 
     /**

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringSearchCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringSearchCursor.java
@@ -495,10 +495,6 @@ public class VectorClusteringSearchCursor implements IIndexCursor {
 
         this.firstDirectoryPageId = allDirectoryPageIds.get(0);
 
-        // System.err.println(String.format(
-        //       "[VectorClusteringSearchCursor.navigateToFirstCluster] Scan complete: totalClusters=%d, collected %d directory pages",
-        //       totalLeafClusters, allDirectoryPageIds.size()));
-
         // Step 4: Open cluster 0
         this.currentSequentialClusterIndex = 0;
         openClusterByDirectoryPage(this.firstDirectoryPageId);
@@ -582,9 +578,6 @@ public class VectorClusteringSearchCursor implements IIndexCursor {
             long firstDataPageId = metadataFrame.getDataPagePointer(0);
             this.currentDataPageId = firstDataPageId;
 
-            //            // System.err.println(String.format(
-            //                    "[VectorClusteringSearchCursor.openClusterByDirectoryPage] Metadata has %d entries, firstDataPage=%d",
-            //                    metadataTupleCount, firstDataPageId));
         } finally {
             dirPage.releaseReadLatch();
             dataBufferCache.unpin(dirPage);

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTreeFlushLoader.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTreeFlushLoader.java
@@ -92,7 +92,6 @@ public class VectorClusteringTreeFlushLoader extends PageWriteFailureCallback im
         System.arraycopy(sourcePage.getBuffer().array(), 0, targetPage.getBuffer().array(), 0,
                 sourcePage.getBuffer().capacity());
         write(targetPage);
-        LOGGER.debug("Flushed VBC page -> disk page {}", diskPageId);
     }
 
     /**

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/utils/VCTreeNavigationUtils.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/utils/VCTreeNavigationUtils.java
@@ -159,28 +159,38 @@ public class VCTreeNavigationUtils {
 
     /**
      * Extract centroid from an interior frame tuple (format: <cid, centroid, child_ptr>).
+     * Reads the centroid vector directly from tuple bytes to avoid full deserialization overhead.
      */
     private static double[] extractCentroidFromInteriorTuple(ITreeIndexTupleReference tuple) {
-        // Centroid is the second field in interior frame tuples
-        try {
-            // Create field serializers array - specify only the centroid field we need
-            ISerializerDeserializer<?>[] fieldSerdes = new ISerializerDeserializer<?>[3];
-            fieldSerdes[0] = IntegerSerializerDeserializer.INSTANCE; // Field 0: cid
-            fieldSerdes[1] = DoubleArraySerializerDeserializer.INSTANCE; // Field 1: centroid
-            fieldSerdes[2] = IntegerSerializerDeserializer.INSTANCE; // Field 2: metadata_pointer
+        // Field 1 is the centroid vector, stored as [4 bytes: len][len * 8 bytes: doubles]
+        byte[] data = tuple.getFieldData(1);
+        int offset = tuple.getFieldStart(1);
+        int fieldLen = tuple.getFieldLength(1);
 
-            // Deserialize the tuple using the proper TupleUtils method
-            Object[] fieldValues = TupleUtils.deserializeTuple(tuple, fieldSerdes);
+        // Read array length (number of doubles)
+        int len = ((data[offset] & 0xFF) << 24) | ((data[offset + 1] & 0xFF) << 16)
+                | ((data[offset + 2] & 0xFF) << 8) | (data[offset + 3] & 0xFF);
 
-            // Extract the centroid from the deserialized fields
-            double[] doubleCentroid = (double[]) fieldValues[1];
-
-            return doubleCentroid;
-
-        } catch (Exception e) {
-            throw new RuntimeException(
-                    "Failed to extract centroid from interior tuple using TupleUtils.deserializeTuple()", e);
+        // Sanity check: len must be positive and consistent with field length
+        int expectedFieldLen = 4 + len * 8;
+        if (len <= 0 || len > 10000 || expectedFieldLen > fieldLen) {
+            throw new RuntimeException(String.format(
+                    "Corrupted centroid in interior tuple: len=%d, fieldLen=%d, expectedFieldLen=%d (page data may be corrupt)",
+                    len, fieldLen, expectedFieldLen));
         }
+
+        // Read doubles directly from bytes
+        double[] centroid = new double[len];
+        offset += 4; // skip length prefix
+        for (int i = 0; i < len; i++) {
+            long bits = ((long) (data[offset] & 0xFF) << 56) | ((long) (data[offset + 1] & 0xFF) << 48)
+                    | ((long) (data[offset + 2] & 0xFF) << 40) | ((long) (data[offset + 3] & 0xFF) << 32)
+                    | ((long) (data[offset + 4] & 0xFF) << 24) | ((long) (data[offset + 5] & 0xFF) << 16)
+                    | ((long) (data[offset + 6] & 0xFF) << 8) | (data[offset + 7] & 0xFF);
+            centroid[i] = Double.longBitsToDouble(bits);
+            offset += 8;
+        }
+        return centroid;
     }
 
     /**
@@ -1116,7 +1126,12 @@ public class VCTreeNavigationUtils {
         List<ChildCentroid> children = new ArrayList<>();
 
         // Collect from first page (already have frame)
-        for (int i = 0; i < initialFrame.getTupleCount(); i++) {
+        int tupleCount = initialFrame.getTupleCount();
+        LOGGER.warn(String.format(
+                "[collectAndSortChildren] pageId=%d, tupleCount=%d, queryDim=%d",
+                startPageId, tupleCount, state.queryVector.length));
+
+        for (int i = 0; i < tupleCount; i++) {
             try {
                 ITreeIndexTupleReference tuple = initialFrame.createTupleReference();
                 tuple.resetByTupleIndex(initialFrame, i);
@@ -1127,15 +1142,22 @@ public class VCTreeNavigationUtils {
                     int childPageId = initialFrame.getChildPageId(i);
                     children.add(new ChildCentroid(childPageId, distance, i));
                 }
-            } catch (Exception e) {
-                // Skip malformed tuples
+            } catch (RuntimeException | OutOfMemoryError e) {
+                LOGGER.error(String.format(
+                        "[collectAndSortChildren] Error reading tuple %d on page %d: %s",
+                        i, startPageId, e.getMessage()), e);
+                throw e;
             }
         }
 
         // Handle overflow pages
         boolean hasOverflow = initialFrame.getOverflowFlagBit();
+        int nextPageId = hasOverflow ? initialFrame.getNextPage() : -1;
+        LOGGER.warn(String.format(
+                "[collectAndSortChildren] pageId=%d, hasOverflow=%b, nextPageId=%d",
+                startPageId, hasOverflow, nextPageId));
+
         if (hasOverflow) {
-            int nextPageId = initialFrame.getNextPage();
             collectChildrenFromOverflow(state, nextPageId, children, distanceFunction);
         }
 
@@ -1151,7 +1173,9 @@ public class VCTreeNavigationUtils {
             IVectorDistanceFunction distanceFunction) throws HyracksDataException {
 
         int currentPageId = pageId;
+        int overflowPageCount = 0;
         while (currentPageId != -1) {
+            overflowPageCount++;
             ICachedPage page = state.bufferCache.pin(BufferedFileHandle.getDiskPageId(state.fileId, currentPageId));
             try {
                 page.acquireReadLatch();
@@ -1159,7 +1183,12 @@ public class VCTreeNavigationUtils {
                         (IVectorClusteringInteriorFrame) state.interiorFrameFactory.createFrame();
                 frame.setPage(page);
 
-                for (int i = 0; i < frame.getTupleCount(); i++) {
+                int tupleCount = frame.getTupleCount();
+                LOGGER.warn(String.format(
+                        "[collectChildrenFromOverflow] overflowPage #%d: pageId=%d, tupleCount=%d",
+                        overflowPageCount, currentPageId, tupleCount));
+
+                for (int i = 0; i < tupleCount; i++) {
                     try {
                         ITreeIndexTupleReference tuple = frame.createTupleReference();
                         tuple.resetByTupleIndex(frame, i);
@@ -1170,13 +1199,20 @@ public class VCTreeNavigationUtils {
                             int childPageId = frame.getChildPageId(i);
                             children.add(new ChildCentroid(childPageId, distance, i));
                         }
-                    } catch (Exception e) {
-                        // Skip malformed tuples
+                    } catch (RuntimeException | OutOfMemoryError e) {
+                        LOGGER.error(String.format(
+                                "[collectChildrenFromOverflow] Error reading tuple %d on overflow page %d: %s",
+                                i, currentPageId, e.getMessage()), e);
+                        throw e;
                     }
                 }
 
                 boolean hasOverflow = frame.getOverflowFlagBit();
-                currentPageId = hasOverflow ? frame.getNextPage() : -1;
+                int nextPageId = hasOverflow ? frame.getNextPage() : -1;
+                LOGGER.warn(String.format(
+                        "[collectChildrenFromOverflow] pageId=%d, hasOverflow=%b, nextPageId=%d",
+                        currentPageId, hasOverflow, nextPageId));
+                currentPageId = nextPageId;
 
             } finally {
                 page.releaseReadLatch();
@@ -1202,7 +1238,12 @@ public class VCTreeNavigationUtils {
         List<LeafCentroid> centroids = new ArrayList<>();
 
         // Collect from first page
-        for (int i = 0; i < initialFrame.getTupleCount(); i++) {
+        int tupleCount = initialFrame.getTupleCount();
+        LOGGER.warn(String.format(
+                "[collectAndSortLeafCentroids] pageId=%d, tupleCount=%d, queryDim=%d",
+                startPageId, tupleCount, state.queryVector.length));
+
+        for (int i = 0; i < tupleCount; i++) {
             try {
                 ITreeIndexTupleReference tuple = initialFrame.createTupleReference();
                 tuple.resetByTupleIndex(initialFrame, i);
@@ -1214,15 +1255,22 @@ public class VCTreeNavigationUtils {
                     long directoryPageId = initialFrame.getMetadataPagePointer(i);
                     centroids.add(new LeafCentroid(centroidId, distance, i, startPageId, centroid, directoryPageId));
                 }
-            } catch (Exception e) {
-                // Skip malformed tuples
+            } catch (RuntimeException | OutOfMemoryError e) {
+                LOGGER.error(String.format(
+                        "[collectAndSortLeafCentroids] Error reading tuple %d on page %d: %s",
+                        i, startPageId, e.getMessage()), e);
+                throw e;
             }
         }
 
         // Handle overflow pages
         boolean hasOverflow = initialFrame.getOverflowFlagBit();
+        int nextPageId = hasOverflow ? initialFrame.getNextLeaf() : -1;
+        LOGGER.warn(String.format(
+                "[collectAndSortLeafCentroids] pageId=%d, hasOverflow=%b, nextPageId=%d",
+                startPageId, hasOverflow, nextPageId));
+
         if (hasOverflow) {
-            int nextPageId = initialFrame.getNextLeaf();
             collectCentroidsFromOverflow(state, nextPageId, centroids, distanceFunction);
         }
 
@@ -1238,14 +1286,21 @@ public class VCTreeNavigationUtils {
             IVectorDistanceFunction distanceFunction) throws HyracksDataException {
 
         int currentPageId = pageId;
+        int overflowPageCount = 0;
         while (currentPageId != -1) {
+            overflowPageCount++;
             ICachedPage page = state.bufferCache.pin(BufferedFileHandle.getDiskPageId(state.fileId, currentPageId));
             try {
                 page.acquireReadLatch();
                 IVectorClusteringLeafFrame frame = (IVectorClusteringLeafFrame) state.leafFrameFactory.createFrame();
                 frame.setPage(page);
 
-                for (int i = 0; i < frame.getTupleCount(); i++) {
+                int tupleCount = frame.getTupleCount();
+                LOGGER.warn(String.format(
+                        "[collectCentroidsFromOverflow] overflowPage #%d: pageId=%d, tupleCount=%d",
+                        overflowPageCount, currentPageId, tupleCount));
+
+                for (int i = 0; i < tupleCount; i++) {
                     try {
                         ITreeIndexTupleReference tuple = frame.createTupleReference();
                         tuple.resetByTupleIndex(frame, i);
@@ -1258,13 +1313,20 @@ public class VCTreeNavigationUtils {
                             centroids.add(new LeafCentroid(centroidId, distance, i, currentPageId, centroid,
                                     directoryPageId));
                         }
-                    } catch (Exception e) {
-                        // Skip malformed tuples
+                    } catch (RuntimeException | OutOfMemoryError e) {
+                        LOGGER.error(String.format(
+                                "[collectCentroidsFromOverflow] Error reading tuple %d on overflow page %d: %s",
+                                i, currentPageId, e.getMessage()), e);
+                        throw e;
                     }
                 }
 
                 boolean hasOverflow = frame.getOverflowFlagBit();
-                currentPageId = hasOverflow ? frame.getNextLeaf() : -1;
+                int nextPageId = hasOverflow ? frame.getNextLeaf() : -1;
+                LOGGER.warn(String.format(
+                        "[collectCentroidsFromOverflow] pageId=%d, hasOverflow=%b, nextPageId=%d",
+                        currentPageId, hasOverflow, nextPageId));
+                currentPageId = nextPageId;
 
             } finally {
                 page.releaseReadLatch();

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/utils/VCTreeNavigationUtils.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/utils/VCTreeNavigationUtils.java
@@ -159,38 +159,18 @@ public class VCTreeNavigationUtils {
 
     /**
      * Extract centroid from an interior frame tuple (format: <cid, centroid, child_ptr>).
-     * Reads the centroid vector directly from tuple bytes to avoid full deserialization overhead.
+     * Uses TupleUtils.deserializeTuple() which correctly handles TypeAwareTupleWriter's
+     * VarLengthInt field size encoding.
      */
-    private static double[] extractCentroidFromInteriorTuple(ITreeIndexTupleReference tuple) {
-        // Field 1 is the centroid vector, stored as [4 bytes: len][len * 8 bytes: doubles]
-        byte[] data = tuple.getFieldData(1);
-        int offset = tuple.getFieldStart(1);
-        int fieldLen = tuple.getFieldLength(1);
+    private static double[] extractCentroidFromInteriorTuple(ITreeIndexTupleReference tuple)
+            throws HyracksDataException {
+        ISerializerDeserializer<?>[] fieldSerdes = new ISerializerDeserializer<?>[3];
+        fieldSerdes[0] = IntegerSerializerDeserializer.INSTANCE;
+        fieldSerdes[1] = DoubleArraySerializerDeserializer.INSTANCE;
+        fieldSerdes[2] = IntegerSerializerDeserializer.INSTANCE;
 
-        // Read array length (number of doubles)
-        int len = ((data[offset] & 0xFF) << 24) | ((data[offset + 1] & 0xFF) << 16)
-                | ((data[offset + 2] & 0xFF) << 8) | (data[offset + 3] & 0xFF);
-
-        // Sanity check: len must be positive and consistent with field length
-        int expectedFieldLen = 4 + len * 8;
-        if (len <= 0 || len > 10000 || expectedFieldLen > fieldLen) {
-            throw new RuntimeException(String.format(
-                    "Corrupted centroid in interior tuple: len=%d, fieldLen=%d, expectedFieldLen=%d (page data may be corrupt)",
-                    len, fieldLen, expectedFieldLen));
-        }
-
-        // Read doubles directly from bytes
-        double[] centroid = new double[len];
-        offset += 4; // skip length prefix
-        for (int i = 0; i < len; i++) {
-            long bits = ((long) (data[offset] & 0xFF) << 56) | ((long) (data[offset + 1] & 0xFF) << 48)
-                    | ((long) (data[offset + 2] & 0xFF) << 40) | ((long) (data[offset + 3] & 0xFF) << 32)
-                    | ((long) (data[offset + 4] & 0xFF) << 24) | ((long) (data[offset + 5] & 0xFF) << 16)
-                    | ((long) (data[offset + 6] & 0xFF) << 8) | (data[offset + 7] & 0xFF);
-            centroid[i] = Double.longBitsToDouble(bits);
-            offset += 8;
-        }
-        return centroid;
+        Object[] fieldValues = TupleUtils.deserializeTuple(tuple, fieldSerdes);
+        return (double[]) fieldValues[1];
     }
 
     /**
@@ -1127,9 +1107,8 @@ public class VCTreeNavigationUtils {
 
         // Collect from first page (already have frame)
         int tupleCount = initialFrame.getTupleCount();
-        LOGGER.warn(String.format(
-                "[collectAndSortChildren] pageId=%d, tupleCount=%d, queryDim=%d",
-                startPageId, tupleCount, state.queryVector.length));
+        LOGGER.warn(String.format("[collectAndSortChildren] pageId=%d, tupleCount=%d, queryDim=%d", startPageId,
+                tupleCount, state.queryVector.length));
 
         for (int i = 0; i < tupleCount; i++) {
             try {
@@ -1137,25 +1116,22 @@ public class VCTreeNavigationUtils {
                 tuple.resetByTupleIndex(initialFrame, i);
                 double[] centroid = extractCentroidFromInteriorTuple(tuple);
 
-                if (centroid.length == state.queryVector.length) {
+                if (centroid != null && centroid.length == state.queryVector.length) {
                     double distance = distanceFunction.apply(state.queryVector, centroid);
                     int childPageId = initialFrame.getChildPageId(i);
                     children.add(new ChildCentroid(childPageId, distance, i));
                 }
-            } catch (RuntimeException | OutOfMemoryError e) {
-                LOGGER.error(String.format(
-                        "[collectAndSortChildren] Error reading tuple %d on page %d: %s",
-                        i, startPageId, e.getMessage()), e);
-                throw e;
+            } catch (Exception e) {
+                LOGGER.warn(String.format("[collectAndSortChildren] Skipping tuple %d on page %d: %s", i, startPageId,
+                        e.getMessage()));
             }
         }
 
         // Handle overflow pages
         boolean hasOverflow = initialFrame.getOverflowFlagBit();
         int nextPageId = hasOverflow ? initialFrame.getNextPage() : -1;
-        LOGGER.warn(String.format(
-                "[collectAndSortChildren] pageId=%d, hasOverflow=%b, nextPageId=%d",
-                startPageId, hasOverflow, nextPageId));
+        LOGGER.warn(String.format("[collectAndSortChildren] pageId=%d, hasOverflow=%b, nextPageId=%d", startPageId,
+                hasOverflow, nextPageId));
 
         if (hasOverflow) {
             collectChildrenFromOverflow(state, nextPageId, children, distanceFunction);
@@ -1184,8 +1160,7 @@ public class VCTreeNavigationUtils {
                 frame.setPage(page);
 
                 int tupleCount = frame.getTupleCount();
-                LOGGER.warn(String.format(
-                        "[collectChildrenFromOverflow] overflowPage #%d: pageId=%d, tupleCount=%d",
+                LOGGER.warn(String.format("[collectChildrenFromOverflow] overflowPage #%d: pageId=%d, tupleCount=%d",
                         overflowPageCount, currentPageId, tupleCount));
 
                 for (int i = 0; i < tupleCount; i++) {
@@ -1194,23 +1169,21 @@ public class VCTreeNavigationUtils {
                         tuple.resetByTupleIndex(frame, i);
                         double[] centroid = extractCentroidFromInteriorTuple(tuple);
 
-                        if (centroid.length == state.queryVector.length) {
+                        if (centroid != null && centroid.length == state.queryVector.length) {
                             double distance = distanceFunction.apply(state.queryVector, centroid);
                             int childPageId = frame.getChildPageId(i);
                             children.add(new ChildCentroid(childPageId, distance, i));
                         }
-                    } catch (RuntimeException | OutOfMemoryError e) {
-                        LOGGER.error(String.format(
-                                "[collectChildrenFromOverflow] Error reading tuple %d on overflow page %d: %s",
-                                i, currentPageId, e.getMessage()), e);
-                        throw e;
+                    } catch (Exception e) {
+                        LOGGER.warn(
+                                String.format("[collectChildrenFromOverflow] Skipping tuple %d on overflow page %d: %s",
+                                        i, currentPageId, e.getMessage()));
                     }
                 }
 
                 boolean hasOverflow = frame.getOverflowFlagBit();
                 int nextPageId = hasOverflow ? frame.getNextPage() : -1;
-                LOGGER.warn(String.format(
-                        "[collectChildrenFromOverflow] pageId=%d, hasOverflow=%b, nextPageId=%d",
+                LOGGER.warn(String.format("[collectChildrenFromOverflow] pageId=%d, hasOverflow=%b, nextPageId=%d",
                         currentPageId, hasOverflow, nextPageId));
                 currentPageId = nextPageId;
 
@@ -1239,9 +1212,8 @@ public class VCTreeNavigationUtils {
 
         // Collect from first page
         int tupleCount = initialFrame.getTupleCount();
-        LOGGER.warn(String.format(
-                "[collectAndSortLeafCentroids] pageId=%d, tupleCount=%d, queryDim=%d",
-                startPageId, tupleCount, state.queryVector.length));
+        LOGGER.warn(String.format("[collectAndSortLeafCentroids] pageId=%d, tupleCount=%d, queryDim=%d", startPageId,
+                tupleCount, state.queryVector.length));
 
         for (int i = 0; i < tupleCount; i++) {
             try {
@@ -1249,26 +1221,23 @@ public class VCTreeNavigationUtils {
                 tuple.resetByTupleIndex(initialFrame, i);
                 double[] centroid = extractCentroidFromInteriorTuple(tuple);
 
-                if (centroid.length == state.queryVector.length) {
+                if (centroid != null && centroid.length == state.queryVector.length) {
                     double distance = distanceFunction.apply(state.queryVector, centroid);
                     int centroidId = initialFrame.getCentroidId(i);
                     long directoryPageId = initialFrame.getMetadataPagePointer(i);
                     centroids.add(new LeafCentroid(centroidId, distance, i, startPageId, centroid, directoryPageId));
                 }
-            } catch (RuntimeException | OutOfMemoryError e) {
-                LOGGER.error(String.format(
-                        "[collectAndSortLeafCentroids] Error reading tuple %d on page %d: %s",
-                        i, startPageId, e.getMessage()), e);
-                throw e;
+            } catch (Exception e) {
+                LOGGER.warn(String.format("[collectAndSortLeafCentroids] Skipping tuple %d on page %d: %s", i,
+                        startPageId, e.getMessage()));
             }
         }
 
         // Handle overflow pages
         boolean hasOverflow = initialFrame.getOverflowFlagBit();
         int nextPageId = hasOverflow ? initialFrame.getNextLeaf() : -1;
-        LOGGER.warn(String.format(
-                "[collectAndSortLeafCentroids] pageId=%d, hasOverflow=%b, nextPageId=%d",
-                startPageId, hasOverflow, nextPageId));
+        LOGGER.warn(String.format("[collectAndSortLeafCentroids] pageId=%d, hasOverflow=%b, nextPageId=%d", startPageId,
+                hasOverflow, nextPageId));
 
         if (hasOverflow) {
             collectCentroidsFromOverflow(state, nextPageId, centroids, distanceFunction);
@@ -1296,8 +1265,7 @@ public class VCTreeNavigationUtils {
                 frame.setPage(page);
 
                 int tupleCount = frame.getTupleCount();
-                LOGGER.warn(String.format(
-                        "[collectCentroidsFromOverflow] overflowPage #%d: pageId=%d, tupleCount=%d",
+                LOGGER.warn(String.format("[collectCentroidsFromOverflow] overflowPage #%d: pageId=%d, tupleCount=%d",
                         overflowPageCount, currentPageId, tupleCount));
 
                 for (int i = 0; i < tupleCount; i++) {
@@ -1306,25 +1274,23 @@ public class VCTreeNavigationUtils {
                         tuple.resetByTupleIndex(frame, i);
                         double[] centroid = extractCentroidFromInteriorTuple(tuple);
 
-                        if (centroid.length == state.queryVector.length) {
+                        if (centroid != null && centroid.length == state.queryVector.length) {
                             double distance = distanceFunction.apply(state.queryVector, centroid);
                             int centroidId = frame.getCentroidId(i);
                             long directoryPageId = frame.getMetadataPagePointer(i);
                             centroids.add(new LeafCentroid(centroidId, distance, i, currentPageId, centroid,
                                     directoryPageId));
                         }
-                    } catch (RuntimeException | OutOfMemoryError e) {
-                        LOGGER.error(String.format(
-                                "[collectCentroidsFromOverflow] Error reading tuple %d on overflow page %d: %s",
-                                i, currentPageId, e.getMessage()), e);
-                        throw e;
+                    } catch (Exception e) {
+                        LOGGER.warn(String.format(
+                                "[collectCentroidsFromOverflow] Skipping tuple %d on overflow page %d: %s", i,
+                                currentPageId, e.getMessage()));
                     }
                 }
 
                 boolean hasOverflow = frame.getOverflowFlagBit();
                 int nextPageId = hasOverflow ? frame.getNextLeaf() : -1;
-                LOGGER.warn(String.format(
-                        "[collectCentroidsFromOverflow] pageId=%d, hasOverflow=%b, nextPageId=%d",
+                LOGGER.warn(String.format("[collectCentroidsFromOverflow] pageId=%d, hasOverflow=%b, nextPageId=%d",
                         currentPageId, hasOverflow, nextPageId));
                 currentPageId = nextPageId;
 

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/utils/LSMVCTreeUtils.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/utils/LSMVCTreeUtils.java
@@ -128,12 +128,22 @@ public class LSMVCTreeUtils {
         interiorTypeTraits[2] = IntegerPointable.TYPE_TRAITS; // pointer (int) - Fixed 4 bytes
 
         // Create specific type traits using primitive type traits for better performance
-        // Interior/Leaf frames need 3-field cluster tuples: <cid, centroid, pointer>
-        ITypeTraits[] leafTypeTraits = new ITypeTraits[4];
-        leafTypeTraits[0] = IntegerPointable.TYPE_TRAITS; // cluster ID (int) - Fixed 4 bytes
-        leafTypeTraits[1] = VarLengthTypeTrait.INSTANCE; // centroid (float array) - Variable
-        leafTypeTraits[2] = VarLengthTypeTrait.INSTANCE; // quantized embedding (float array) Variable
-        leafTypeTraits[3] = IntegerPointable.TYPE_TRAITS; // pointer (int) - Fixed 4 bytes
+        // Leaf frames: field count depends on whether quantization is enabled
+        // Without quantization: 3-field <cid, centroid, pointer>
+        // With quantization: 4-field <cid, centroid, quantized_embedding, pointer>
+        ITypeTraits[] leafTypeTraits;
+        if (quantizationParams != null) {
+            leafTypeTraits = new ITypeTraits[4];
+            leafTypeTraits[0] = IntegerPointable.TYPE_TRAITS; // cluster ID (int) - Fixed 4 bytes
+            leafTypeTraits[1] = VarLengthTypeTrait.INSTANCE; // centroid (float array) - Variable
+            leafTypeTraits[2] = VarLengthTypeTrait.INSTANCE; // quantized embedding (float array) - Variable
+            leafTypeTraits[3] = IntegerPointable.TYPE_TRAITS; // pointer (int) - Fixed 4 bytes
+        } else {
+            leafTypeTraits = new ITypeTraits[3];
+            leafTypeTraits[0] = IntegerPointable.TYPE_TRAITS; // cluster ID (int) - Fixed 4 bytes
+            leafTypeTraits[1] = VarLengthTypeTrait.INSTANCE; // centroid (float array) - Variable
+            leafTypeTraits[2] = IntegerPointable.TYPE_TRAITS; // pointer (int) - Fixed 4 bytes
+        }
 
         // Metadata frames need 2-field metadata tuples: <max_distance, page_pointer>
         ITypeTraits[] metadataTypeTraits = new ITypeTraits[2];


### PR DESCRIPTION
- Initialize overflow flag byte to 0 in initBuffer() for both InteriorFrame and LeafFrame; garbage byte caused bulk loader to compute wrong overflow pointer (-1 + staticBasePageId), leading to OOM/corruption at query time
- Fix DROP INDEX failure (ASX1070) by accepting both "train_list_number" and "train_list" keys in metadata roundtrip, persisting num_clusters, and fixing string reference comparison (== to .equals())
- Add localCentroidDirPageMap in VectorClusteringSearchCursor to resolve directory page IDs from this component's own leaf pages instead of relying on ClusterSearchResult IDs from a different component
- Harden extractCentroidFromInteriorTuple with bounds checking and add diagnostic logging to overflow page traversal