### PR TITLE
Cherry-pick open-include-fields fix, remove diagnostic logs

### DIFF
--- a/asterixdb/asterix-app/src/main/java/org/apache/asterix/app/translator/QueryTranslator.java
+++ b/asterixdb/asterix-app/src/main/java/org/apache/asterix/app/translator/QueryTranslator.java
@@ -1580,7 +1580,7 @@ public class QueryTranslator extends AbstractLangTranslator implements IStatemen
                     }
 
                     if (fieldTypePrime == null) {
-                        if (indexType != IndexType.BTREE) {
+                        if (indexType != IndexType.BTREE && indexType != IndexType.VECTOR) {
                             if (projectPath != null) {
                                 String fieldName =
                                         LogRedactionUtil.userData(RecordUtil.toFullyQualifiedName(projectPath));

--- a/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/utils/SecondaryVectorOperationsHelper.java
+++ b/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/utils/SecondaryVectorOperationsHelper.java
@@ -40,6 +40,7 @@ import org.apache.asterix.metadata.declared.MetadataProvider;
 import org.apache.asterix.metadata.entities.Dataset;
 import org.apache.asterix.metadata.entities.Index;
 import org.apache.asterix.metadata.entities.InternalDatasetDetails;
+import org.apache.asterix.metadata.utils.KeyFieldTypeUtil;
 import org.apache.asterix.object.base.AdmObjectNode;
 import org.apache.asterix.om.pointables.base.DefaultOpenFieldType;
 import org.apache.asterix.om.types.AOrderedListType;

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/api/IVCTreeDataTupleCreator.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/api/IVCTreeDataTupleCreator.java
@@ -75,6 +75,19 @@ public interface IVCTreeDataTupleCreator {
     }
 
     /**
+     * Sets quantization parameters so that the 4-arg {@link #createDataTuple}
+     * can perform actual scalar quantization instead of serializing
+     * full-precision vectors.
+     *
+     * Default implementation is a no-op (for non-quantized creators).
+     *
+     * @param quantizationParams {minQuantile, maxQuantile, alpha, confidenceInterval, bits, sampleCount}
+     */
+    default void setQuantizationParams(float[] quantizationParams) {
+        // no-op for non-quantized implementations
+    }
+
+    /**
      * Returns the field index of the primary key in the output data tuple.
      * Callers use this to locate the PK when reading stored tuples.
      *

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/QuantizedVCTreeDataTupleCreator.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/QuantizedVCTreeDataTupleCreator.java
@@ -60,19 +60,46 @@ public class QuantizedVCTreeDataTupleCreator implements IVCTreeDataTupleCreator 
     private static final int PK_FIELD_INDEX = 4;
     private final int numIncludeFields;
 
+    // Quantization parameters: {minQuantile, maxQuantile, alpha, confidenceInterval, bits, sampleCount}
+    // null = not yet initialized (falls back to full-precision serialization for unit tests)
+    private float[] quantizationParams;
+
     public QuantizedVCTreeDataTupleCreator(int numIncludeFields) {
         this.numIncludeFields = numIncludeFields;
     }
 
     @Override
+    public void setQuantizationParams(float[] quantizationParams) {
+        this.quantizationParams = quantizationParams;
+    }
+
+    @Override
     public ITupleReference createDataTuple(double[] vector, double distance, int centroidId,
             ITupleReference originalTuple) throws HyracksDataException {
-        // Test mode pass-through: serialize the full-precision vector as raw big-endian doubles
-        ByteBuffer buf = ByteBuffer.allocate(vector.length * Double.BYTES);
-        for (double d : vector) {
-            buf.putDouble(d);
+        byte[] quantizedEmbedding;
+        if (quantizationParams != null) {
+            // Production path: perform actual scalar quantization
+            float minQ = quantizationParams[0];
+            float maxQ = quantizationParams[1];
+            float alpha = quantizationParams[2];
+            int bits = (int) quantizationParams[4];
+            int levels = 1 << bits;
+            quantizedEmbedding = new byte[vector.length];
+            for (int i = 0; i < vector.length; i++) {
+                double value = Math.max(minQ, Math.min(maxQ, vector[i]));
+                int quantizedValue = Math.toIntExact(Math.round((value - minQ) * alpha));
+                quantizedValue = Math.max(0, Math.min(levels - 1, quantizedValue));
+                quantizedEmbedding[i] = (byte) quantizedValue;
+            }
+        } else {
+            // Test mode fallback: serialize the full-precision vector as raw big-endian doubles
+            ByteBuffer buf = ByteBuffer.allocate(vector.length * Double.BYTES);
+            for (double d : vector) {
+                buf.putDouble(d);
+            }
+            quantizedEmbedding = buf.array();
         }
-        return createDataTuple(vector, distance, centroidId, originalTuple, distance, buf.array());
+        return createDataTuple(vector, distance, centroidId, originalTuple, distance, quantizedEmbedding);
     }
 
     @Override

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringSearchCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringSearchCursor.java
@@ -37,6 +37,7 @@ import org.apache.hyracks.storage.am.vector.api.IVectorClusteringLeafFrame;
 import org.apache.hyracks.storage.am.vector.api.IVectorClusteringMetadataFrame;
 import org.apache.hyracks.storage.am.vector.api.IVectorDistanceFunction;
 import org.apache.hyracks.storage.am.vector.api.IVectorQuantizer;
+import org.apache.hyracks.storage.am.vector.utils.VCTreeNavigationFrame;
 import org.apache.hyracks.storage.am.vector.utils.VCTreeNavigationState;
 import org.apache.hyracks.storage.am.vector.utils.VCTreeNavigationUtils;
 import org.apache.hyracks.storage.am.vector.utils.VectorUtils;
@@ -369,8 +370,7 @@ public class VectorClusteringSearchCursor implements IIndexCursor {
             return true;
         }
 
-        // Current cluster exhausted - return false
-        // Let the LSM layer decide whether to advance to next cluster
+        // Current cluster exhausted - let the LSM layer decide whether to advance to next cluster
         return false;
     }
 
@@ -389,7 +389,7 @@ public class VectorClusteringSearchCursor implements IIndexCursor {
             this.currentTuple = this.frameTuple;
         }
         currentTupleIndex++;
-        recordsIterated++; // Track how many records we've iterated through
+        recordsIterated++;
     }
 
     @Override
@@ -528,6 +528,7 @@ public class VectorClusteringSearchCursor implements IIndexCursor {
      * Used by full-scan mode for sequential cluster iteration.
      */
     private void openClusterByDirectoryPage(long directoryPageId) throws HyracksDataException {
+        // Log previous cluster summary if we have data
         this.targetMetadataPageId = directoryPageId;
 
         // Guard: directoryPageId=-1 means empty cluster (no data assigned during bulk loading)
@@ -687,6 +688,20 @@ public class VectorClusteringSearchCursor implements IIndexCursor {
 
         // Get next from DFS (automatically skips visited via NavigationState)
         return VCTreeNavigationUtils.findNextClosestCluster(iteratorState, distanceFunction);
+    }
+
+    /**
+     * Reset the DFS iterator so the first centroid (consumed by initializeClusterIterator)
+     * can be re-discovered. Called when the DFS init cluster is discarded in favor of the
+     * level-wise first cluster.
+     */
+    public void resetDfsFirstCentroid() {
+        if (iteratorState != null && iteratorState.initialized && !iteratorState.stack.isEmpty()) {
+            VCTreeNavigationFrame topFrame = iteratorState.stack.peek();
+            if (topFrame.isLeaf && topFrame.nextIndex > 0) {
+                topFrame.nextIndex--;
+            }
+        }
     }
 
     /**

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTree.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorClusteringTree.java
@@ -1289,6 +1289,8 @@ public class VectorClusteringTree extends AbstractTreeIndex {
                     tree.metadataFrameFactory, tree.dataFrameFactory, tree.freePageManager, tree.cmpFactories,
                     tree.vectorDimensions, iap.getModificationCallback(), iap.getSearchOperationCallback(),
                     tree.dataTupleCreatorFactory);
+            // Pass quantization params to the data tuple creator for actual SQ quantization
+            ctx.getDataTupleCreator().setQuantizationParams(tree.quantizationParams);
         }
 
         public void reset(VectorClusteringTree vctree, IIndexAccessParameters iap) {

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/utils/VCTreeNavigationUtils.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/utils/VCTreeNavigationUtils.java
@@ -362,8 +362,9 @@ public class VCTreeNavigationUtils {
                             new VCTreeNavigationFrame(currentPageId, sortedCentroids, true);
                     state.stack.push(leafFrame_nav);
 
-                    // Return first centroid as closest cluster
+                    // Return first centroid as closest cluster, marking it visited
                     VCTreeLeafCentroid first = leafFrame_nav.nextCentroid();
+                    state.markVisited(first.centroidId);
                     return ClusterSearchResult.create(first.pageId, first.tupleIndex, first.centroid, first.distance,
                             first.centroidId, first.directoryPageId);
 

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/LSMVCTreeLocalResource.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/LSMVCTreeLocalResource.java
@@ -48,6 +48,7 @@ import org.apache.hyracks.storage.am.lsm.common.dataflow.LsmResource;
 import org.apache.hyracks.storage.am.lsm.vector.utils.LSMVCTreeUtils;
 import org.apache.hyracks.storage.am.vector.api.IVCTreeDataTupleCreatorFactory;
 import org.apache.hyracks.storage.am.vector.api.IVectorBinaryAccessorFactory;
+import org.apache.hyracks.storage.am.vector.impls.QuantizedVCTreeDataTupleCreatorFactory;
 import org.apache.hyracks.storage.am.vector.impls.VCTreeDataTupleCreatorFactory;
 import org.apache.hyracks.storage.common.IIndex;
 import org.apache.hyracks.storage.common.IStorageManager;
@@ -340,7 +341,14 @@ public class LSMVCTreeLocalResource extends LsmResource implements IQuantizedRes
         Float alpha = getOrDefaultFloat(json, "alpha", null);
         Integer bits = getOrDefaultInt(json, "bits", null);
         Integer sampleCount = getOrDefaultInt(json, "sampleCount", null);
-        IVCTreeDataTupleCreatorFactory dataTupleCreatorFactory = new VCTreeDataTupleCreatorFactory(numIncludeFields);
+        // Determine quantized vs non-quantized based on presence of quantization parameters
+        boolean isQuantized = (minQuantile != null);
+        IVCTreeDataTupleCreatorFactory dataTupleCreatorFactory;
+        if (isQuantized) {
+            dataTupleCreatorFactory = new QuantizedVCTreeDataTupleCreatorFactory(numIncludeFields);
+        } else {
+            dataTupleCreatorFactory = new VCTreeDataTupleCreatorFactory(numIncludeFields);
+        }
 
         return new LSMVCTreeLocalResource(registry, json, vectorDimensions, vectorFields, filterFields, atomic,
                 indexName, confidenceInterval, minQuantile, maxQuantile, alpha, bits, sampleCount, null,

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeSearchCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeSearchCursor.java
@@ -287,6 +287,11 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
                             vcCursor.openClusterByResult(firstCluster);
                         }
                     }
+
+                    // The DFS init centroid was discarded - un-mark it from visited
+                    // and reset the DFS leaf frame so it can be re-discovered later
+                    visitedSet.remove(dfsCluster.centroidId);
+                    firstCursor.resetDfsFirstCentroid();
                 }
 
                 LOGGER.log(Level.TRACE,


### PR DESCRIPTION
- Cherry-pick commit 1b6a90f290 to allow VECTOR indexes with open-type INCLUDE fields
- Fix DFS/level-wise cluster conflict: reset DFS first centroid when level-wise disagrees
- Add quantization support to QuantizedVCTreeDataTupleCreator for actual SQ quantization
- Use QuantizedVCTreeDataTupleCreatorFactory for quantized indexes in LSMVCTreeLocalResource