### PR TITLE
Revamp vector index DDL syntax and ANN query parameters

### DIFF
--- a/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/optimizer/rules/am/VectorIndexAccessMethod.java
+++ b/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/optimizer/rules/am/VectorIndexAccessMethod.java
@@ -129,7 +129,7 @@ public class VectorIndexAccessMethod implements IAccessMethod {
                 return false;
             }
         } else {
-            // ann_distance(vectorField, queryVector, metric [, nprobe, epsilon])
+            // ann_distance(vectorField, queryVector, metric [, min_probe_fraction, k_multiplier])
             if (funcExpr.getArguments().size() < 3 || funcExpr.getArguments().size() > 5) {
                 return false;
             }
@@ -274,24 +274,26 @@ public class VectorIndexAccessMethod implements IAccessMethod {
         boolean isVectorDistance =
                 annDistanceExpr.getFunctionIdentifier().equals(BuiltinFunctions.VECTOR_DISTANCE_ARRAY);
 
-        // Add nprobe variable (arg 3 for ANN_DISTANCE, default 10)
-        // SQL++ parser creates AInt64 for integer literals; convert to AInt32 for IntegerPointable at runtime
-        LogicalVariable nprobeVar = context.newVar();
-        queryVarList.add(nprobeVar);
+        // Add min_probe_fraction variable (arg 3 for ANN_DISTANCE, default 0.1)
+        // Fraction of leaf clusters to probe (0.0-1.0). 0 means use default (0.1).
+        // Converted to nprobe = max(1, floor(totalLeafClusters * fraction)) at runtime.
+        LogicalVariable minProbeFractionVar = context.newVar();
+        queryVarList.add(minProbeFractionVar);
         if (!isVectorDistance && annDistanceExpr.getArguments().size() > 3) {
-            ILogicalExpression nprobeExpr = annDistanceExpr.getArguments().get(3).getValue().cloneExpression();
-            queryExprList.add(new MutableObject<>(ensureInt32Constant(nprobeExpr)));
+            queryExprList.add(new MutableObject<>(annDistanceExpr.getArguments().get(3).getValue().cloneExpression()));
         } else {
-            queryExprList.add(new MutableObject<>(new ConstantExpression(new AsterixConstantValue(new AInt32(10)))));
+            queryExprList.add(new MutableObject<>(new ConstantExpression(new AsterixConstantValue(new ADouble(0.1)))));
         }
 
-        // Add epsilon variable (arg 4 for ANN_DISTANCE, default 0.15)
-        LogicalVariable epsilonVar = context.newVar();
-        queryVarList.add(epsilonVar);
+        // Add k_multiplier variable (arg 4 for ANN_DISTANCE, default 1)
+        // Multiplier for candidate limit: K * kMultiplier candidates collected for reranking.
+        LogicalVariable kMultiplierVar = context.newVar();
+        queryVarList.add(kMultiplierVar);
         if (!isVectorDistance && annDistanceExpr.getArguments().size() > 4) {
-            queryExprList.add(new MutableObject<>(annDistanceExpr.getArguments().get(4).getValue().cloneExpression()));
+            ILogicalExpression kMultExpr = annDistanceExpr.getArguments().get(4).getValue().cloneExpression();
+            queryExprList.add(new MutableObject<>(ensureInt32Constant(kMultExpr)));
         } else {
-            queryExprList.add(new MutableObject<>(new ConstantExpression(new AsterixConstantValue(new ADouble(0.15)))));
+            queryExprList.add(new MutableObject<>(new ConstantExpression(new AsterixConstantValue(new AInt32(1)))));
         }
 
         // Add search_approach variable (always 0 for ann_distance, 4 for vector_distance)

--- a/asterixdb/asterix-doc/src/main/grammar/sqlpp.ebnf
+++ b/asterixdb/asterix-doc/src/main/grammar/sqlpp.ebnf
@@ -213,8 +213,11 @@ Properties ::= ( "(" Identifier "=" ( StringLiteral | IntegerLiteral ) ( "," Ide
 CreateIndex ::= CreateSecondaryIndex | CreatePrimaryKeyIndex
 
 CreateSecondaryIndex ::= "CREATE" "INDEX" Identifier ("IF" "NOT" "EXISTS")? "ON" QualifiedName
-                       "(" IndexedElement ( "," IndexedElement )* ")" ("TYPE" IndexType)? ("ENFORCED")?
+                       "(" IndexedElement ( "," IndexedElement )* ")"
+                       ( "INCLUDE" "(" NestedField ( "," NestedField )* ")" )?
+                       ("TYPE" IndexType)? ("ENFORCED")?
                        (( "EXCLUDE" | "INCLUDE" ) "UNKNOWN" "KEY")?
+                       ( "WITH" RecordConstructor )?
 
 CreatePrimaryKeyIndex ::= "CREATE" "PRIMARY" "INDEX" Identifier? ("IF" "NOT" "EXISTS")? "ON" QualifiedName ("TYPE" "BTREE")?
 
@@ -225,13 +228,14 @@ IndexedElement ::= ArrayIndexElement
 ArrayIndexElement ::= "UNNEST" NestedField ( "UNNEST" NestedField )*
                       ( ( ":" TypeReference ) | ( "SELECT" NestedField ( ":" TypeReference )? ( "," NestedField ( ":" TypeReference )? )* ) )?
 
-IndexField ::= NestedField ( ":" TypeReference "?"? )?
+IndexField ::= NestedField ( ( ":" TypeReference "?"? ) | "VECTOR" )?
 
 IndexType ::= "BTREE"
              |"RTREE"
              |"KEYWORD"
              |"FULLTEXT"
              |"NGRAM" "(" IntegerLiteral ")"
+             |"VTREE"
 
 CreateSynonym ::= "CREATE" "SYNONYM" QualifiedName "FOR" QualifiedName ("IF" "NOT" "EXISTS")?
 

--- a/asterixdb/asterix-lang-common/src/main/java/org/apache/asterix/lang/common/util/VectorIndexDeclUtil.java
+++ b/asterixdb/asterix-lang-common/src/main/java/org/apache/asterix/lang/common/util/VectorIndexDeclUtil.java
@@ -21,6 +21,7 @@ package org.apache.asterix.lang.common.util;
 import org.apache.asterix.common.exceptions.CompilationException;
 import org.apache.asterix.lang.common.expression.RecordConstructor;
 import org.apache.asterix.object.base.AdmObjectNode;
+import org.apache.asterix.object.base.AdmStringNode;
 import org.apache.asterix.om.types.ARecordType;
 import org.apache.asterix.om.types.AUnionType;
 import org.apache.asterix.om.types.BuiltinType;
@@ -38,6 +39,7 @@ public class VectorIndexDeclUtil {
     public static final String VECTOR_INDEX_PARAMETER_TRAIN_LIST_FRACTION = "train_list_fraction";
     public static final String VECTOR_INDEX_PARAMETER_SIMILARITY = "similarity";
     public static final String VECTOR_INDEX_PARAMETER_NUM_K = "num_clusters";
+    public static final String VECTOR_INDEX_DEFAULT_QUANTIZATION = "SQ8";
 
     private static final ARecordType WITH_OBJECT_TYPE = getWithObjectType();
 
@@ -51,6 +53,13 @@ public class VectorIndexDeclUtil {
         final ConfigurationTypeValidator validator = new ConfigurationTypeValidator();
         final AdmObjectNode node = ExpressionUtils.toNode(withRecord);
         validator.validateType(WITH_OBJECT_TYPE, node);
+
+        // Default quantization to SQ8 if not specified
+        String quantization = node.getOptionalString(VECTOR_INDEX_PARAMETER_QUANTIZATION, null);
+        if (quantization == null) {
+            node.set(VECTOR_INDEX_PARAMETER_QUANTIZATION, new AdmStringNode(VECTOR_INDEX_DEFAULT_QUANTIZATION));
+        }
+
         return node;
     }
 

--- a/asterixdb/asterix-lang-sqlpp/src/main/javacc/SQLPP.jj
+++ b/asterixdb/asterix-lang-sqlpp/src/main/javacc/SQLPP.jj
@@ -1504,11 +1504,10 @@ void DatasetRecordField(RecordTypeDefinition recType) throws ParseException:
 CreateIndexStatement CreateIndexStatement(Token startStmtToken) throws ParseException:
 {
   CreateIndexStatement stmt = null;
-  boolean isVectorIndex = false;
 }
 {
   (
-    ( <VECTOR> { isVectorIndex = true; } )? <INDEX> stmt = IndexSpecification(startStmtToken, isVectorIndex)
+    <INDEX> stmt = IndexSpecification(startStmtToken)
     | <PRIMARY> <INDEX> stmt = PrimaryIndexSpecification(startStmtToken)
   )
   {
@@ -1516,7 +1515,7 @@ CreateIndexStatement CreateIndexStatement(Token startStmtToken) throws ParseExce
   }
 }
 
-CreateIndexStatement IndexSpecification(Token startStmtToken, boolean isVectorIndex) throws ParseException:
+CreateIndexStatement IndexSpecification(Token startStmtToken) throws ParseException:
 {
   Pair<Namespace,Identifier> nameComponents = null;
   String indexName = null;
@@ -1557,31 +1556,9 @@ CreateIndexStatement IndexSpecification(Token startStmtToken, boolean isVectorIn
         }
       )*
     <RIGHTPAREN>
-    ( <TYPE> indexParams = IndexType() )? ( <ENFORCED> { enforced = true; } )?
-    // Parse INCLUDE/EXCLUDE UNKNOWN KEY (for non-vector indexes)
-    // Lookahead checks that INCLUDE/EXCLUDE is followed by UNKNOWN to disambiguate from INCLUDE (fields)
-    ( LOOKAHEAD({(laIdentifier(EXCLUDE) || laIdentifier(INCLUDE)) && laToken(2, UNKNOWN)}) <IDENTIFIER>
-    {
-      if (isToken(EXCLUDE)) {
-        excludeUnknown = true;
-      } else if (isToken(INCLUDE)) {
-        excludeUnknown = false;
-      } else {
-        throw createUnexpectedTokenError();
-      }
-    } <UNKNOWN> <KEY>
-    )?
 
-    ( <CAST><LEFTPAREN> castConfigDefaultNull = CastDefaultNull() <RIGHTPAREN>
-      {
-        castConfig = castConfigDefaultNull.first;
-        castDefaultNull = castConfigDefaultNull.second;
-      }
-    )?
-
-    // Parse INCLUDE clause for vector index additional fields (e.g., INCLUDE (year, title))
+    // Parse INCLUDE clause for vector index additional fields (e.g., INCLUDE(title, popularity))
     // Lookahead checks that INCLUDE is followed by LEFTPAREN to disambiguate from INCLUDE UNKNOWN KEY
-    // This allows filtering on these fields during vector search
     ( LOOKAHEAD({laIdentifier(INCLUDE) && laToken(2, LEFTPAREN)}) <IDENTIFIER>
       {
         if (!isToken(INCLUDE)) {
@@ -1600,14 +1577,34 @@ CreateIndexStatement IndexSpecification(Token startStmtToken, boolean isVectorIn
       <RIGHTPAREN>
     )?
 
+    ( <TYPE> indexParams = IndexType() )? ( <ENFORCED> { enforced = true; } )?
+
     // Parse WITH clause for vector index configuration
     ( <WITH> withRecord = RecordConstructor() )?
+
+    // Parse INCLUDE/EXCLUDE UNKNOWN KEY
+    // Lookahead checks that INCLUDE/EXCLUDE is followed by UNKNOWN to disambiguate from INCLUDE(fields)
+    ( LOOKAHEAD({(laIdentifier(EXCLUDE) || laIdentifier(INCLUDE)) && laToken(2, UNKNOWN)}) <IDENTIFIER>
+    {
+      if (isToken(EXCLUDE)) {
+        excludeUnknown = true;
+      } else if (isToken(INCLUDE)) {
+        excludeUnknown = false;
+      } else {
+        throw createUnexpectedTokenError();
+      }
+    } <UNKNOWN> <KEY>
+    )?
+
+    ( <CAST><LEFTPAREN> castConfigDefaultNull = CastDefaultNull() <RIGHTPAREN>
+      {
+        castConfig = castConfigDefaultNull.first;
+        castDefaultNull = castConfigDefaultNull.second;
+      }
+    )?
   )
   {
-    // Auto-detect vector index from VECTOR field type annotation
-      // This allows both syntaxes:
-      // - CREATE VECTOR INDEX ix1 ON Movie1(embedding VECTOR) WITH {...}
-      // - CREATE INDEX ix1 ON Movie1(embedding VECTOR) WITH {...}
+      // Check if VECTOR field type annotation is present
       boolean hasVectorField = false;
       if (indexedElementList.size() == 1) {
         CreateIndexStatement.IndexedElement field = indexedElementList.get(0);
@@ -1628,18 +1625,25 @@ CreateIndexStatement IndexSpecification(Token startStmtToken, boolean isVectorIn
         }
       }
 
-      // If VECTOR field annotation detected OR CREATE VECTOR INDEX used, treat as vector index
-      if (hasVectorField || isVectorIndex) {
+      boolean isVTree = indexParams != null && indexParams.type == IndexType.VECTOR;
+
+      // Validate: VECTOR annotation requires TYPE VTREE
+      if (hasVectorField && !isVTree) {
+        throw new SqlppParseException(getSourceLocation(startStmtToken),
+          "VECTOR field annotation requires TYPE VTREE. Expected syntax: CREATE INDEX ... (field VECTOR) TYPE VTREE WITH {...} EXCLUDE UNKNOWN KEY");
+      }
+
+      // Validate: TYPE VTREE requires VECTOR annotation
+      if (isVTree && !hasVectorField) {
+        throw new SqlppParseException(getSourceLocation(startStmtToken),
+          "TYPE VTREE requires VECTOR field annotation. Expected syntax: CREATE INDEX ... (field VECTOR) TYPE VTREE WITH {...} EXCLUDE UNKNOWN KEY");
+      }
+
+      if (isVTree) {
         // Validate exactly one field for vector index
         if (indexedElementList.size() != 1) {
           throw new SqlppParseException(getSourceLocation(startStmtToken),
             "Vector index requires exactly one field");
-        }
-
-        // Validate that VECTOR type annotation is present
-        if (!hasVectorField) {
-          throw new SqlppParseException(getSourceLocation(startStmtToken),
-            "Vector index field must have VECTOR type annotation. Expected syntax: CREATE [VECTOR] INDEX ... (field VECTOR) WITH {...}");
         }
 
         // Validate that WITH clause is provided
@@ -1648,19 +1652,31 @@ CreateIndexStatement IndexSpecification(Token startStmtToken, boolean isVectorIn
             "Vector index requires WITH clause specifying index configuration");
         }
 
+        // Validate that EXCLUDE UNKNOWN KEY is specified
+        if (excludeUnknown == null || !excludeUnknown) {
+          throw new SqlppParseException(getSourceLocation(startStmtToken),
+            "Vector index requires EXCLUDE UNKNOWN KEY");
+        }
+
         // Create vector index statement
         try {
           CreateIndexStatement stmt = CreateIndexStatement.CreateVectorIndexStatement(
             nameComponents.first, nameComponents.second,
             new Identifier(indexName),
             indexedElementList.get(0),  // vectorField
-            nonVectorFieldsList,         // empty for new syntax (no INC clause)
+            nonVectorFieldsList,         // INCLUDE fields
             withRecord,
             ifNotExists);
           return addSourceLocation(stmt, startStmtToken);
         } catch (CompilationException e) {
           throw new SqlppParseException(getSourceLocation(startStmtToken), e.getMessage());
         }
+      }
+
+      // Validate: INCLUDE clause is only for vector indexes
+      if (!nonVectorFieldsList.isEmpty()) {
+        throw new SqlppParseException(getSourceLocation(startStmtToken),
+          "INCLUDE clause is only supported for vector indexes (TYPE VTREE)");
       }
 
       // Handle regular (non-vector) index creation
@@ -1685,13 +1701,6 @@ CreateIndexStatement IndexSpecification(Token startStmtToken, boolean isVectorIn
       }
     }
 }
-
-// Old CreateVectorIndexStatement and VectorIndexSpecification functions removed.
-// Vector indexes are now created via the unified IndexSpecification grammar which auto-detects
-// vector indexes from the VECTOR field type annotation.
-// Both syntaxes are supported:
-// - CREATE VECTOR INDEX ix1 ON Movie1(embedding VECTOR) WITH {...}
-// - CREATE INDEX ix1 ON Movie1(embedding VECTOR) WITH {...}
 
 CreateIndexStatement.IndexedElement IndexedElement(Token startElementToken) throws ParseException:
 {
@@ -1893,7 +1902,12 @@ IndexParams IndexType() throws ParseException:
       type = IndexType.LENGTH_PARTITIONED_NGRAM_INVIX;
       gramLength = Integer.valueOf(token.image);
     }
-  <RIGHTPAREN>)
+  <RIGHTPAREN>
+  | <VTREE>
+    {
+      type = IndexType.VECTOR;
+    }
+  )
     {
       return new IndexParams(type, gramLength, fullTextConfig);
     }
@@ -6760,6 +6774,7 @@ TOKEN [IGNORE_CASE]:
   | <VALUED : "valued">
   | <VECTOR : "vector">
   | <VIEW : "view">
+  | <VTREE : "vtree">
   | <WHEN : "when">
   | <WHERE : "where">
   | <WITH : "with">

--- a/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/declared/MetadataProvider.java
+++ b/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/declared/MetadataProvider.java
@@ -873,15 +873,16 @@ public class MetadataProvider implements IMetadataProvider<DataSourceId, String>
             // Non-quantized without SET: keep 0 (naive streaming)
         }
 
-        // Read kMultiplier from session config (default 2, clamp to [1, 100])
-        int kMultiplier = 2;
+        // Read kMultiplier from session config (default 1, clamp to [1, 100])
+        // Session config overrides query arg when set (kMultiplier > 1 signals override to NodePushable)
+        int kMultiplier = 1;
         String kmultStr = (String) getConfig().get(CompilerProperties.COMPILER_VECTOR_KMULTIPLIER_KEY);
         if (kmultStr != null && !kmultStr.trim().isEmpty()) {
             try {
                 int parsed = Integer.parseInt(kmultStr.trim());
                 kMultiplier = Math.max(1, parsed);
             } catch (NumberFormatException e) {
-                LOGGER.warn("Invalid compiler.vector.kmultiplier '{}', using default 2", kmultStr);
+                LOGGER.warn("Invalid compiler.vector.kmultiplier '{}', using default 1", kmultStr);
             }
         }
 

--- a/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/entitytupletranslators/IndexTupleTranslator.java
+++ b/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/entitytupletranslators/IndexTupleTranslator.java
@@ -392,7 +392,7 @@ public class IndexTupleTranslator extends AbstractTupleTranslator<Index> {
                         Triple<IAType, Boolean, Boolean> projectTypeResult =
                                 KeyFieldTypeUtil.getKeyProjectType((ARecordType) inputTypePrime, projectPath, null);
                         if (projectTypeResult == null) {
-                            if (indexType != IndexType.BTREE) {
+                            if (indexType != IndexType.BTREE && indexType != IndexType.VECTOR) {
                                 throw new AsterixException(ErrorCode.METADATA_ERROR, projectPath.toString());
                             }
                             projectTypePrime = BuiltinType.ANY;

--- a/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/evaluators/functions/vector/VectorDistanceArrScalarEvaluator.java
+++ b/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/evaluators/functions/vector/VectorDistanceArrScalarEvaluator.java
@@ -171,16 +171,17 @@ public class VectorDistanceArrScalarEvaluator implements IScalarEvaluator {
     public VectorDistanceArrScalarEvaluator(IEvaluatorContext context,
             final IScalarEvaluatorFactory[] evaluatorFactories, FunctionIdentifier funcId, SourceLocation sourceLoc)
             throws HyracksDataException {
-        if (evaluatorFactories.length != 3) {
+        if (evaluatorFactories.length < 3 || evaluatorFactories.length > 5) {
             throw new RuntimeDataException(ErrorCode.COMPILATION_ERROR, sourceLoc,
                     String.format(
-                            "Invalid number of arguments for function %s. Expected 3 arguments: (vector1, vector2, metric)",
+                            "Invalid number of arguments for function %s. Expected 3-5 arguments: (vector1, vector2, metric [, min_probe_fraction] [, k_multiplier])",
                             funcId.getName()));
         }
 
-        pointables = new IPointable[evaluatorFactories.length];
-        evaluators = new IScalarEvaluator[evaluatorFactories.length];
-        for (int i = 0; i < evaluators.length; ++i) {
+        // Only use first 3 args for distance computation; args 3-4 are optimizer hints
+        pointables = new IPointable[3];
+        evaluators = new IScalarEvaluator[3];
+        for (int i = 0; i < 3; ++i) {
             pointables[i] = new VoidPointable();
             evaluators[i] = evaluatorFactories[i].createScalarEvaluator(context);
             // Only process constant optimization for the first 3 args (vector1, vector2, metric).

--- a/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/operators/VCTreeBulkLoaderAndGroupingOperatorDescriptor.java
+++ b/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/operators/VCTreeBulkLoaderAndGroupingOperatorDescriptor.java
@@ -74,6 +74,10 @@ import org.apache.hyracks.storage.common.IIndexAccessor;
 import org.apache.hyracks.storage.common.IResource;
 import org.apache.hyracks.storage.common.LocalResource;
 import org.apache.hyracks.util.string.UTF8StringUtil;
+import org.apache.hyracks.api.exceptions.IWarningCollector;
+import org.apache.hyracks.api.exceptions.Warning;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Operator that handles bulk loader initialization and recursive data grouping to run files.
@@ -88,6 +92,7 @@ import org.apache.hyracks.util.string.UTF8StringUtil;
 public class VCTreeBulkLoaderAndGroupingOperatorDescriptor extends AbstractSingleActivityOperatorDescriptor {
 
     private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = LogManager.getLogger();
     private final IIndexDataflowHelperFactory indexHelperFactory;
     private final float fillFactor; // TODO: Use fillFactor in future bulk loading operations
     private final UUID permitUUID;
@@ -402,9 +407,10 @@ public class VCTreeBulkLoaderAndGroupingOperatorDescriptor extends AbstractSingl
                 return null;
             }
 
-            // Validate embedding dimensions
+            // Validate embedding dimensions — return empty array as sentinel for mismatch
+            // (null = missing field/silent, empty = dimension mismatch/warn)
             if (embedding.length != vectorDimension) {
-                return null;
+                return new double[0];
             }
 
             return embedding;
@@ -476,6 +482,7 @@ public class VCTreeBulkLoaderAndGroupingOperatorDescriptor extends AbstractSingl
         private MaterializerTaskState materializedData;
         int successfulQueries = 0;
         int totalTuplesProcessed = 0;
+        int dimensionMismatchCount = 0;
 
         // Output infrastructure for transformed tuples
         private FrameTupleAppender outputAppender;
@@ -1019,6 +1026,11 @@ public class VCTreeBulkLoaderAndGroupingOperatorDescriptor extends AbstractSingl
                         // Extract embedding from tuple
                         double[] embedding = extractEmbeddingFromTuple(tuple, ctx);
 
+                        // Dimension mismatch: returns empty array (length 0) vs missing field: returns null
+                        if (embedding != null && embedding.length == 0) {
+                            dimensionMismatchCount++;
+                        }
+
                         if (embedding != null && embedding.length > 0) {
                             // Find closest centroid using the extracted embedding
                             // Use accessor to find closest leaf centroid with distance function
@@ -1212,8 +1224,17 @@ public class VCTreeBulkLoaderAndGroupingOperatorDescriptor extends AbstractSingl
 
         @Override
         public void close() throws HyracksDataException {
-            //            System.err.println("Total tuples processed: " + totalTuplesProcessed);
-            //            System.err.println("Successful extractions: " + successfulQueries);
+            // Emit client-facing warning for dimension mismatches
+            if (dimensionMismatchCount > 0) {
+                LOGGER.warn("Vector index build: {} records skipped due to embedding dimension mismatch (expected {})",
+                        dimensionMismatchCount, vectorDimension);
+                IWarningCollector warningCollector = ctx.getWarningCollector();
+                if (warningCollector.shouldWarn()) {
+                    warningCollector.warn(Warning.of(null, org.apache.asterix.common.exceptions.ErrorCode.COMPILATION_ERROR,
+                            String.format("Vector index build: %d records skipped due to embedding dimension mismatch (expected %d)",
+                                    dimensionMismatchCount, vectorDimension)));
+                }
+            }
 
             try {
                 // CRITICAL: Write any remaining output data before closing

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorSearchPredicate.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-btree/src/main/java/org/apache/hyracks/storage/am/vector/impls/VectorSearchPredicate.java
@@ -41,54 +41,48 @@ public class VectorSearchPredicate implements ISearchPredicate {
     private String distanceMetric;
     private int k; // Number of nearest neighbors to return (for ANN queries)
     private ITupleFilter tupleFilter; // Filter for INCLUDE field predicates (e.g., year > 2000)
-    private int nprobe; // Number of clusters to probe (minimum before K-check)
-    private double epsilon; // Distance threshold for level-wise cross-pollination
+    private double minProbeFraction; // Fraction of leaf clusters to probe (0.0-1.0, default 0.1)
+    private int nprobeOverride; // Direct nprobe override for internal/merge use (-1 = not set, use minProbeFraction)
+    private double epsilon; // Distance threshold for level-wise cross-pollination (internal, not user-facing)
     private int searchApproach; // 0 = naive (LSMVCTreeSearchCursor), 1 = optimized (LSMVCTreeBlockedCursor)
     private int pkStartField; // Field index where primary keys start (2 for non-quantized, 4 for quantized)
-    private int kMultiplier; // Multiplier for candidate limit: K * kMultiplier sent to PK for reranking (default 2)
+    private int kMultiplier; // Multiplier for candidate limit: K * kMultiplier sent to PK for reranking (default 1)
+
+    private static final double DEFAULT_MIN_PROBE_FRACTION = 0.1;
+    private static final double DEFAULT_EPSILON = 0.3;
+    private static final int DEFAULT_K_MULTIPLIER = 1;
 
     public VectorSearchPredicate() {
-        // Empty constructor for initialization
         this.distanceMetric = null;
-        this.k = Integer.MAX_VALUE; // Default: no limit
-        this.nprobe = 5; // Default: probe 1 cluster
-        this.epsilon = 0.15; // Default: no epsilon (use nprobe count only)
-        this.searchApproach = 0; // Default: naive search
-        this.pkStartField = 2; // Default: non-quantized format
-        this.kMultiplier = 2; // Default: 2*K candidates for reranking
+        this.k = Integer.MAX_VALUE;
+        this.minProbeFraction = DEFAULT_MIN_PROBE_FRACTION;
+        this.nprobeOverride = -1;
+        this.epsilon = DEFAULT_EPSILON;
+        this.searchApproach = 0;
+        this.pkStartField = 2;
+        this.kMultiplier = DEFAULT_K_MULTIPLIER;
     }
 
     public VectorSearchPredicate(int k) {
-        // Constructor for ANN queries with K parameter
         this.k = k;
         this.distanceMetric = null;
-        this.nprobe = 5;
-        this.epsilon = 0.15;
+        this.minProbeFraction = DEFAULT_MIN_PROBE_FRACTION;
+        this.nprobeOverride = -1;
+        this.epsilon = DEFAULT_EPSILON;
         this.searchApproach = 0;
         this.pkStartField = 2;
-        this.kMultiplier = 2;
-    }
-
-    public VectorSearchPredicate(int k, int nprobe, double epsilon) {
-        // Constructor for ANN queries with K, nprobe, and epsilon parameters
-        this.k = k;
-        this.nprobe = nprobe;
-        this.epsilon = epsilon;
-        this.distanceMetric = null;
-        this.searchApproach = 0;
-        this.pkStartField = 2;
-        this.kMultiplier = 2;
+        this.kMultiplier = DEFAULT_K_MULTIPLIER;
     }
 
     public VectorSearchPredicate(double[] queryVector) {
         // Constructor kept for compatibility with tests
-        // In runtime, query data comes via setQueryTuple()
-        this.k = Integer.MAX_VALUE; // Default: no limit
-        this.nprobe = 5;
-        this.epsilon = 0.15;
+        this.k = Integer.MAX_VALUE;
+        this.minProbeFraction = DEFAULT_MIN_PROBE_FRACTION;
+        this.nprobeOverride = -1;
+        this.epsilon = DEFAULT_EPSILON;
         this.searchApproach = 0;
         this.pkStartField = 2;
-        this.kMultiplier = 2;
+        this.kMultiplier = DEFAULT_K_MULTIPLIER;
     }
 
     /**
@@ -149,18 +143,48 @@ public class VectorSearchPredicate implements ISearchPredicate {
     }
 
     /**
-     * Set the nprobe parameter (number of clusters to probe).
-     * This is the minimum number of clusters to explore before checking if K is satisfied.
+     * Set the min_probe_fraction parameter (fraction of leaf clusters to probe).
+     * Converted to nprobe = max(1, floor(totalLeafClusters * fraction)) at runtime.
+     * Value of 0 means use default (0.1).
      */
-    public void setNprobe(int nprobe) {
-        this.nprobe = nprobe;
+    public void setMinProbeFraction(double minProbeFraction) {
+        if (minProbeFraction <= 0.0) {
+            this.minProbeFraction = DEFAULT_MIN_PROBE_FRACTION;
+        } else if (minProbeFraction > 1.0) {
+            this.minProbeFraction = 1.0;
+        } else {
+            this.minProbeFraction = minProbeFraction;
+        }
     }
 
     /**
-     * Get the nprobe parameter (number of clusters to probe).
+     * Get the min_probe_fraction parameter.
+     */
+    public double getMinProbeFraction() {
+        return minProbeFraction;
+    }
+
+    /**
+     * Set nprobe directly (for internal/test/merge use, e.g., Integer.MAX_VALUE for merge mode).
+     * When nprobeOverride > 0, it takes precedence over minProbeFraction in the strategy.
+     */
+    public void setNprobe(int nprobe) {
+        this.nprobeOverride = nprobe;
+    }
+
+    /**
+     * Get nprobe override. Returns -1 if not set (use minProbeFraction instead).
+     */
+    public int getNprobeOverride() {
+        return nprobeOverride;
+    }
+
+    /**
+     * @deprecated Use getMinProbeFraction() or getNprobeOverride() instead.
+     * Kept for compatibility with VectorClusteringSearchCursor.extractNprobe().
      */
     public int getNprobe() {
-        return nprobe;
+        return nprobeOverride > 0 ? nprobeOverride : 5;
     }
 
     /**
@@ -257,8 +281,9 @@ public class VectorSearchPredicate implements ISearchPredicate {
 
     @Override
     public String toString() {
-        return "VectorPointPredicate[queryTuple=" + (queryTuple != null ? "set" : "null") + ", distanceMetric="
-                + distanceMetric + ", k=" + k + ", nprobe=" + nprobe + ", epsilon=" + epsilon + ", searchApproach="
-                + searchApproach + ", pkStartField=" + pkStartField + "]";
+        return "VectorSearchPredicate[queryTuple=" + (queryTuple != null ? "set" : "null") + ", distanceMetric="
+                + distanceMetric + ", k=" + k + ", minProbeFraction=" + minProbeFraction + ", epsilon=" + epsilon
+                + ", kMultiplier=" + kMultiplier + ", searchApproach=" + searchApproach + ", pkStartField="
+                + pkStartField + "]";
     }
 }

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/VectorSearchOperatorNodePushable.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/dataflow/VectorSearchOperatorNodePushable.java
@@ -184,18 +184,19 @@ public class VectorSearchOperatorNodePushable extends IndexSearchOperatorNodePus
                 vectorPred.setDistanceMetric(distanceMetric);
             }
 
-            // Extract nprobe from field 3 (int, +1 to skip type tag)
+            // Extract min_probe_fraction from field 3 (double, +1 to skip type tag)
+            // Fraction of leaf clusters to probe (0.0-1.0). 0 means use default (0.1).
             if (queryFields.length > 3) {
-                int nprobe = IntegerPointable.getInteger(queryParamsTuple.getFieldData(3),
+                double minProbeFraction = DoublePointable.getDouble(queryParamsTuple.getFieldData(3),
                         queryParamsTuple.getFieldStart(3) + 1);
-                vectorPred.setNprobe(nprobe);
+                vectorPred.setMinProbeFraction(minProbeFraction);
             }
 
-            // Extract epsilon from field 4 (double, +1 to skip type tag)
+            // Extract k_multiplier from field 4 (int, +1 to skip type tag)
             if (queryFields.length > 4) {
-                double epsilon = DoublePointable.getDouble(queryParamsTuple.getFieldData(4),
+                int queryKMult = IntegerPointable.getInteger(queryParamsTuple.getFieldData(4),
                         queryParamsTuple.getFieldStart(4) + 1);
-                vectorPred.setEpsilon(epsilon);
+                vectorPred.setKMultiplier(Math.max(1, queryKMult));
             }
 
             // Set tuple filter for INCLUDE field predicates (e.g., year > 2000)
@@ -204,8 +205,10 @@ public class VectorSearchOperatorNodePushable extends IndexSearchOperatorNodePus
                 vectorPred.setTupleFilter(tupleFilter);
             }
 
-            // Set kMultiplier for candidate limit (K * kMultiplier sent to PK for reranking)
-            vectorPred.setKMultiplier(kMultiplier);
+            // Session config compiler.vector.kmultiplier overrides query arg if set (kMultiplier > 1 from constructor)
+            if (kMultiplier > 1) {
+                vectorPred.setKMultiplier(kMultiplier);
+            }
         }
     }
 

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeBlockedCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeBlockedCursor.java
@@ -178,7 +178,7 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
         this.K = vectorPred.getK();
         int mult = vectorPred.getKMultiplier();
         this.candidateLimit = K * Math.max(1, mult); // Send K*kMultiplier to PK for reranking
-        this.nprobe = vectorPred.getNprobe();
+        this.nprobe = 1; // Will be computed by NprobeClusterSelectionStrategy from minProbeFraction
         this.epsilon = vectorPred.getEpsilon();
         this.pkStartField = vectorPred.getPkStartField();
 
@@ -207,7 +207,7 @@ public class LSMVCTreeBlockedCursor implements IIndexCursor {
         if (Boolean.TRUE.equals(useSequentialScan)) {
             this.clusterStrategy = new SequentialClusterSelectionStrategy();
         } else {
-            this.clusterStrategy = new NprobeClusterSelectionStrategy(nprobe, epsilon);
+            this.clusterStrategy = new NprobeClusterSelectionStrategy(vectorPred.getMinProbeFraction(), epsilon);
         }
 
         // Initialize priority queues

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeBlockedNaiveCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeBlockedNaiveCursor.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import org.apache.hyracks.api.exceptions.HyracksDataException;
 import org.apache.hyracks.api.util.HyracksConstants;
 import org.apache.hyracks.data.std.primitive.ByteArrayPointable;
-import org.apache.hyracks.data.std.primitive.DoublePointable;
 import org.apache.hyracks.data.std.primitive.LongPointable;
 import org.apache.hyracks.dataflow.common.data.accessors.ITupleReference;
 import org.apache.hyracks.dataflow.common.utils.TupleUtils;
@@ -172,7 +171,7 @@ public class LSMVCTreeBlockedNaiveCursor implements IIndexCursor {
         this.K = vectorPred.getK();
         int mult = vectorPred.getKMultiplier();
         this.candidateLimit = K * Math.max(1, mult); // Send K*kMultiplier to PK for reranking
-        this.nprobe = vectorPred.getNprobe();
+        this.nprobe = 1; // Will be computed by NprobeClusterSelectionStrategy from minProbeFraction
         this.epsilon = vectorPred.getEpsilon();
         this.pkStartField = vectorPred.getPkStartField();
 
@@ -195,8 +194,8 @@ public class LSMVCTreeBlockedNaiveCursor implements IIndexCursor {
             this.vectorAccessor = vectorAccessorFactory.createAccessor();
         }
 
-        // Create cluster selection strategy (nprobe + DFS fallback)
-        this.clusterStrategy = new NprobeClusterSelectionStrategy(nprobe, epsilon);
+        // Create cluster selection strategy (minProbeFraction → nprobe + DFS fallback)
+        this.clusterStrategy = new NprobeClusterSelectionStrategy(vectorPred.getMinProbeFraction(), epsilon);
 
         // Top-K window: capacity = candidateLimit (2*K) for reranking
         topKWindow = new PriorityQueue<>(Math.max(candidateLimit, 1), (a, b) -> Double.compare(b.dqx, a.dqx));
@@ -626,15 +625,6 @@ public class LSMVCTreeBlockedNaiveCursor implements IIndexCursor {
         System.arraycopy(data, contentOffset, qBytes, 0, contentLength);
         double[] dequantized = quantizer.dequantize(qBytes);
         return distanceFunction.apply(quantizedQueryVector, dequantized);
-    }
-
-    /**
-     * Extract D(x, C) from tuple. First field is distance_to_centroid.
-     */
-    private double extractDistanceToCentroid(ITupleReference tuple) {
-        byte[] data = tuple.getFieldData(0);
-        int offset = tuple.getFieldStart(0);
-        return DoublePointable.getDouble(data, offset);
     }
 
     /**

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeSearchCursor.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/LSMVCTreeSearchCursor.java
@@ -153,17 +153,18 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
         // Extract pkStartField from search predicate for conditional tuple format
         this.pkStartField = ((VectorSearchPredicate) searchPred).getPkStartField();
 
-        // Extract nprobe and epsilon from search predicate
-        this.nprobe = extractNprobe(searchPred);
+        // Extract minProbeFraction and epsilon from search predicate
+        double minProbeFraction = extractMinProbeFraction(searchPred);
         double epsilon = extractEpsilon(searchPred);
+        this.nprobe = 1; // Will be computed by NprobeClusterSelectionStrategy from minProbeFraction
 
         // Create cluster selection strategy based on mode
         if (fullScanMode) {
             // Merge mode: sequential cluster iteration, no early termination
             this.clusterStrategy = new SequentialClusterSelectionStrategy();
         } else {
-            // Query mode: level-wise + DFS, nprobe/K-based early termination
-            this.clusterStrategy = new NprobeClusterSelectionStrategy(nprobe, epsilon);
+            // Query mode: level-wise + DFS, minProbeFraction/K-based early termination
+            this.clusterStrategy = new NprobeClusterSelectionStrategy(minProbeFraction, epsilon);
         }
 
         // Extract tuple filter from search predicate for INCLUDE field predicates
@@ -852,10 +853,10 @@ public class LSMVCTreeSearchCursor extends LSMIndexSearchCursor {
     }
 
     /**
-     * Extract nprobe value from search predicate (minimum clusters to probe before K-check).
+     * Extract minProbeFraction from search predicate (fraction of leaf clusters to probe).
      */
-    private int extractNprobe(ISearchPredicate searchPred) {
-        return ((VectorSearchPredicate) searchPred).getNprobe();
+    private double extractMinProbeFraction(ISearchPredicate searchPred) {
+        return ((VectorSearchPredicate) searchPred).getMinProbeFraction();
     }
 
     /**

--- a/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/NprobeClusterSelectionStrategy.java
+++ b/hyracks-fullstack/hyracks/hyracks-storage-am-lsm-btree/src/main/java/org/apache/hyracks/storage/am/lsm/vector/impls/NprobeClusterSelectionStrategy.java
@@ -47,8 +47,9 @@ public class NprobeClusterSelectionStrategy implements IClusterSelectionStrategy
     private static final Logger LOGGER = LogManager.getLogger();
 
     // Parameters
-    private final int nprobe;
+    private final double minProbeFraction;
     private final double epsilon;
+    private int nprobe; // Computed from minProbeFraction * totalLeafClusters at initialize time
     private int K;
 
     // Level-wise state
@@ -66,9 +67,10 @@ public class NprobeClusterSelectionStrategy implements IClusterSelectionStrategy
     // For DFS fallback
     private VectorClusteringSearchCursor firstCursor;
 
-    public NprobeClusterSelectionStrategy(int nprobe, double epsilon) {
-        this.nprobe = nprobe;
+    public NprobeClusterSelectionStrategy(double minProbeFraction, double epsilon) {
+        this.minProbeFraction = minProbeFraction;
         this.epsilon = epsilon;
+        this.nprobe = 1; // Will be computed in initialize() from minProbeFraction * totalLeafClusters
         this.visitedCentroidIds = new HashSet<>();
     }
 
@@ -93,6 +95,10 @@ public class NprobeClusterSelectionStrategy implements IClusterSelectionStrategy
                         vcTree.getNavigationRootPageId(), vcTree.getInteriorFrameFactory(),
                         vcTree.getLeafFrameFactory(), queryVector, distFunc, epsilon, quantizedQueryVector, quantizer);
 
+                // Compute nprobe from minProbeFraction * totalLeafClusters
+                int totalLeafClusters = globalLevelWiseClusters != null ? globalLevelWiseClusters.size() : 1;
+                this.nprobe = Math.max(1, (int) Math.floor(totalLeafClusters * minProbeFraction));
+
                 // Mark first cluster as visited and start getNextCluster() from index 1
                 // The cursor handles index 0 separately via getFirstCluster()
                 if (globalLevelWiseClusters != null && !globalLevelWiseClusters.isEmpty()) {
@@ -101,8 +107,9 @@ public class NprobeClusterSelectionStrategy implements IClusterSelectionStrategy
                 }
 
                 LOGGER.log(Level.TRACE,
-                        String.format("[NprobeStrategy] Computed %d level-wise clusters with epsilon=%.2f",
-                                globalLevelWiseClusters != null ? globalLevelWiseClusters.size() : 0, epsilon));
+                        String.format(
+                                "[NprobeStrategy] Computed %d level-wise clusters with epsilon=%.2f, minProbeFraction=%.2f, nprobe=%d",
+                                totalLeafClusters, epsilon, minProbeFraction, nprobe));
             } catch (Exception e) {
                 LOGGER.log(Level.TRACE,
                         String.format("[NprobeStrategy] Failed to compute level-wise clusters: %s", e.getMessage()));
@@ -223,6 +230,10 @@ public class NprobeClusterSelectionStrategy implements IClusterSelectionStrategy
     // Getters for logging/debugging
     public int getNprobe() {
         return nprobe;
+    }
+
+    public double getMinProbeFraction() {
+        return minProbeFraction;
     }
 
     public double getEpsilon() {


### PR DESCRIPTION
DDL: Replace CREATE VECTOR INDEX with CREATE INDEX ... TYPE VTREE.
- Remove leading VECTOR keyword; require TYPE VTREE + VECTOR field annotation
- Add INCLUDE(...) clause for storing fields in the index
- WITH clause and EXCLUDE UNKNOWN KEY are mandatory for VTREE
- Default quantization to SQ8 when not specified
- Add VTREE to IndexType in SQLPP.jj grammar and EBNF

ANN query: Replace nprobe/epsilon args with min_probe_fraction/k_multiplier.
- arg3: min_probe_fraction (double 0-1, default 0.1, 0=use default) Converted to nprobe = max(1, floor(totalLeafClusters * fraction)) at runtime
- arg4: k_multiplier (int, default 1); session config still overrides
- Default epsilon changed to 0.3 (internal, not user-facing)
- Runtime evaluator accepts 3-5 args (extra args are optimizer hints)

Fixes and validation:
- Allow VECTOR index type in IndexTupleTranslator metadata resolution
- Dimension mismatch warning (LOGGER + IWarningCollector) during bulk load
- Clamp min_probe_fraction to [0, 1]